### PR TITLE
Bump JDK to version 6.

### DIFF
--- a/jflex/pom.xml
+++ b/jflex/pom.xml
@@ -124,7 +124,7 @@
             </goals>
             <configuration>
               <target name="cup">
-                <property name="cup.version" value="11b"/>
+
                 <property name="cup.jar" value="lib/java-cup-${cup.version}.jar"/>
                 <property name="cup.output.dir" location="target/generated-sources/jflex/"/>
                 <property name="cup.file" location="src/main/cup/LexParse.cup"/>
@@ -253,7 +253,7 @@
         <artifactId>maven-pmd-plugin</artifactId>
         <version>3.0.1</version>
         <configuration>
-          <targetJdk>1.5</targetJdk>
+          <targetJdk>${jflex.jdk.version}</targetJdk>
           <rulesets>
             <ruleset>${basedir}/src/main/config/pmd/ruleset.xml</ruleset>
           </rulesets>
@@ -338,6 +338,7 @@
     </profile>
   </profiles>
   <properties>
+    <cup.version>11b</cup.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,10 @@
     <maven>3.0.0</maven>
   </prerequisites>
 
+  <properties>
+    <jflex.jdk.version>6</jflex.jdk.version>
+  </properties>
+
   <issueManagement>
     <system>Sourceforge</system>
     <url>http://sourceforge.net/p/jflex/_list/tickets</url>
@@ -146,8 +150,8 @@
           <artifactId>maven-compiler-plugin</artifactId>
           <version>3.1</version>
           <configuration>
-            <source>1.5</source>
-            <target>1.5</target>
+            <source>${jflex.jdk.version}</source>
+            <target>${jflex.jdk.version}</target>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
Cup 11b now requires JDK 6 to compile.
Since we now use cub 11b (see #175), bump our prerequesite from Jdk 5 to jdk 6.