### PR TITLE
Marked plugin as thread safe

### DIFF
--- a/jflex-maven-plugin/pom.xml
+++ b/jflex-maven-plugin/pom.xml
@@ -44,7 +44,7 @@
     <url>https://github.com/jflex-de/jflex/issues</url>
   </issueManagement>
   <prerequisites>
-    <maven>3.0.1</maven>
+    <maven>${maven.version}</maven>
   </prerequisites>
   <inceptionYear>2007</inceptionYear>
   <developers>
@@ -90,6 +90,7 @@
   </licenses>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.version>3.0.5</maven.version>
   </properties>
   <build>
     <plugins>
@@ -102,10 +103,6 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.1</version>
-        <configuration>
-          <source>${jflex.jdk.version}</source>
-          <target>${jflex.jdk.version}</target>
-        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -226,12 +223,12 @@
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
-      <version>2.2.1</version>
+      <version>${maven.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.maven.shared</groupId>
+      <groupId>org.apache.maven.plugin-testing</groupId>
       <artifactId>maven-plugin-testing-harness</artifactId>
-      <version>1.1</version>
+      <version>2.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -242,12 +239,24 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>1.4</version>
+      <version>2.2</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
-      <artifactId>maven-project</artifactId>
-      <version>2.2.1</version>
+      <artifactId>maven-core</artifactId>
+      <version>${maven.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.plugin-tools</groupId>
+      <artifactId>maven-plugin-annotations</artifactId>
+      <version>3.4</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-compat</artifactId>
+      <version>${maven.version}</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
   <reporting>

--- a/jflex-unicode-maven-plugin/pom.xml
+++ b/jflex-unicode-maven-plugin/pom.xml
@@ -102,15 +102,6 @@
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.apache.maven.plugin-testing</groupId>
-      <artifactId>maven-plugin-testing-harness</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.maven</groupId>
-      <artifactId>maven-project</artifactId>
-    </dependency>
   </dependencies>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,8 @@
 
   <properties>
     <jflex.jdk.version>1.7</jflex.jdk.version>
+    <maven.compiler.source>${jflex.jdk.version}</maven.compiler.source>
+    <maven.compiler.target>${jflex.jdk.version}</maven.compiler.target>
   </properties>
 
   <issueManagement>
@@ -102,7 +104,7 @@
       <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
-        <version>1.2</version>
+        <version>2.2</version>
       </dependency>
       <dependency>
         <groupId>junit</groupId>
@@ -118,16 +120,6 @@
         <groupId>org.apache.maven</groupId>
         <artifactId>maven-plugin-api</artifactId>
         <version>3.1.0</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.maven.plugin-testing</groupId>
-        <artifactId>maven-plugin-testing-harness</artifactId>
-        <version>2.1</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.maven</groupId>
-        <artifactId>maven-project</artifactId>
-        <version>2.0.11</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -169,10 +161,6 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
           <version>3.1</version>
-          <configuration>
-            <source>${jflex.jdk.version}</source>
-            <target>${jflex.jdk.version}</target>
-          </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/testsuite/jflex-testsuite-maven-plugin/pom.xml
+++ b/testsuite/jflex-testsuite-maven-plugin/pom.xml
@@ -107,10 +107,6 @@
       <artifactId>maven-plugin-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.maven</groupId>
-      <artifactId>maven-project</artifactId>
-    </dependency>
-    <dependency>
       <groupId>de.jflex</groupId>
       <artifactId>jflex</artifactId>
       <version>1.7.0-SNAPSHOT</version>


### PR DESCRIPTION
Updated to maven-plugin-api 3.0.5 and introduced Mojo annotations. Marked JFlexMojo as thread-safe. Closes #211