### PR TITLE
Fix simple spell check issues

### DIFF
--- a/jflex/examples/interpreter/SymtabEntry.java
+++ b/jflex/examples/interpreter/SymtabEntry.java
@@ -12,7 +12,7 @@
  * Symbol table entry for names, there are subclasses for
  * variables and functions.
  * 
- * Defines constants UNKNOWN, VAR und FUN as kinds of
+ * Defines constants UNKNOWN, VAR and FUN as kinds of
  * symbol table entries.
  */ 
 class SymtabEntry {

--- a/jflex/examples/interpreter/Tdekl.java
+++ b/jflex/examples/interpreter/Tdekl.java
@@ -12,7 +12,7 @@
  * AST node for function declarations.
  * 
  * Also contains a reference to the symbol table of 
- * the paramaters and their arity.
+ * the parameters and their arity.
  */ 
 class Tdekl implements AST {
   Tident ident;               // identifier

--- a/jflex/examples/interpreter/Texp.java
+++ b/jflex/examples/interpreter/Texp.java
@@ -12,7 +12,7 @@
  * AST node for an integer expression.
  * 
  * The non terminal exp is the sum of multiple variants and
- * therefore modeled as an abstract class.
+ * therefore modelled as an abstract class.
  * 
  * The interpretation function <tt>interpret</tt> is called with
  * valuations of input variables <tt>in</tt> and parameters

--- a/jflex/examples/simple-maven/src/main/java/Utility.java
+++ b/jflex/examples/simple-maven/src/main/java/Utility.java
@@ -1,6 +1,6 @@
 /**
  * A small utility class.
- * TODO: use reosurce bundle
+ * TODO: use resource bundle
  */
 class Utility {
   

--- a/jflex/examples/zero-reader/FunkyReader.java
+++ b/jflex/examples/zero-reader/FunkyReader.java
@@ -16,7 +16,7 @@ import java.io.IOException;
 /**
  * Reader that returns 0 chars read every once in a while.
  * 
- * This is a demonstration of a problematics Reader that does not
+ * This is a demonstration of a problematic Reader that does not
  * implement the Reader specification correctly. Do not use.
  */
 public class FunkyReader extends Reader {

--- a/jflex/src/main/java/java_cup/runtime/DefaultSymbolFactory.java
+++ b/jflex/src/main/java/java_cup/runtime/DefaultSymbolFactory.java
@@ -17,7 +17,7 @@ public class DefaultSymbolFactory implements SymbolFactory{
     // Factory methods
     /**
      * DefaultSymbolFactory for CUP.
-     * Users are strongly encoraged to use ComplexSymbolFactory instead, since
+     * Users are strongly encouraged to use ComplexSymbolFactory instead, since
      * it offers more detailed information about Symbols in source code.
      * Yet since migrating has always been a critical process, You have the
      * chance of still using the oldstyle Symbols.

--- a/jflex/src/main/java/jflex/Action.java
+++ b/jflex/src/main/java/jflex/Action.java
@@ -188,7 +188,7 @@ final public class Action {
    * Sets the lookahead kind and data for this action
    * 
    * @param kind   which kind of lookahead it is
-   * @param data   the length for fixed length look aheads.
+   * @param data   the length for fixed length lookaheads.
    *   
    */
   public void setLookAction(int kind, int data) {

--- a/jflex/src/main/java/jflex/CharClassInterval.java
+++ b/jflex/src/main/java/jflex/CharClassInterval.java
@@ -13,7 +13,7 @@ package jflex;
  * Stores an interval of characters together with the character class
  *
  * A character belongs to an interval, if its Unicode value is greater than or equal
- * to the Unicode value of <CODE>start</code> and smaller than or euqal to the Unicode
+ * to the Unicode value of <CODE>start</code> and smaller than or equal to the Unicode
  * value of <CODE>end</code>.
  *
  * All characters of the interval must belong to the same character class.

--- a/jflex/src/main/java/jflex/Interval.java
+++ b/jflex/src/main/java/jflex/Interval.java
@@ -23,7 +23,7 @@ public final class Interval {
   
 
   /**
-   * Constuct a new interval from <code>start</code> to <code>end</code>.
+   * Construct a new interval from <code>start</code> to <code>end</code>.
    *
    * @param start  first character the interval should contain
    * @param end    last  character the interval should contain

--- a/jflex/src/main/java/jflex/Macros.java
+++ b/jflex/src/main/java/jflex/Macros.java
@@ -59,7 +59,7 @@ final public class Macros {
 
 
   /**
-   * Marks a makro as used.
+   * Marks a macro as used.
    *
    * @return <code>true</code>, iff the macro name has been
    *         stored before.
@@ -119,7 +119,7 @@ final public class Macros {
 
   /**
    * Expands all stored macros, so that getDefinition always returns
-   * a defintion that doesn't contain any macro usages.
+   * a definition that doesn't contain any macro usages.
    *
    * @throws MacroException   if there is a cycle in the macro usage graph.
    */

--- a/jflex/src/main/java/jflex/Options.java
+++ b/jflex/src/main/java/jflex/Options.java
@@ -13,7 +13,7 @@ import java.io.File;
 
 /**
  * Collects all global JFlex options. Can be set from command line parser,
- * ant taks, gui, etc.
+ * ant task, gui, etc.
  * 
  * @author Gerwin Klein
  * @version JFlex 1.7.0-SNAPSHOT

--- a/jflex/src/main/java/jflex/Out.java
+++ b/jflex/src/main/java/jflex/Out.java
@@ -22,7 +22,7 @@ import java.awt.TextArea;
  * Use the switches verbose, time and DUMP at compile time to determine
  * the verbosity of JFlex output. There is no switch for
  * suppressing error messages. verbose and time can be overridden 
- * by command line paramters.
+ * by command line parameters.
  *
  * Redirects output to a TextArea in GUI mode.
  *

--- a/jflex/src/main/java/jflex/ScannerException.java
+++ b/jflex/src/main/java/jflex/ScannerException.java
@@ -50,7 +50,7 @@ public class ScannerException extends RuntimeException {
   /**
    * Creates a new ScannerException for a file with a message only.
    *
-   * @param file      the file in which the error occured
+   * @param file      the file in which the error occurred
    * @param message   the code for the error description presented to the user.
    */
   public ScannerException(File file, ErrorMessages message) {

--- a/jflex/src/main/java/jflex/Skeleton.java
+++ b/jflex/src/main/java/jflex/Skeleton.java
@@ -81,7 +81,7 @@ public class Skeleton {
   /**
    * Make the skeleton private.
    *
-   * Replaces all occurences of " public " in the skeleton with " private ". 
+   * Replaces all occurrences of " public " in the skeleton with " private ". 
    */
   public static void makePrivate() {
     for (int i=0; i < line.length; i++) {

--- a/jflex/src/main/java/jflex/Timer.java
+++ b/jflex/src/main/java/jflex/Timer.java
@@ -26,7 +26,7 @@ public class Timer {
 
 
   /**
-   * Construct a new timer that starts immediatly.
+   * Construct a new timer that starts immediately.
    */
   public Timer() {
     startTime = System.currentTimeMillis();

--- a/testsuite/testcases/src/test/cases/ccl-pre/ccl2.test
+++ b/testsuite/testcases/src/test/cases/ccl-pre/ccl2.test
@@ -1,7 +1,7 @@
 name: ccl2
 
 description:
-bug-test for [:jletter:] style predefiend character classes (#467827)
+bug-test for [:jletter:] style predefined character classes (#467827)
 
 jflex: --nobak --dump --noinputstreamctor
 

--- a/testsuite/testcases/src/test/cases/cup2private/edu/tum/cup2/generator/LookaheadGenerator.java
+++ b/testsuite/testcases/src/test/cases/cup2private/edu/tum/cup2/generator/LookaheadGenerator.java
@@ -143,7 +143,7 @@ public class LookaheadGenerator
 	
 	/**
 	 * @param curItem The item which is currently handled
-	 * @param curDepth The recusrion depth the algorithm is actually in. > 0 means processing the items symbols (first),
+	 * @param curDepth The recursion depth the algorithm is actually in. > 0 means processing the items symbols (first),
 	 *           < 0 means somewhere behind the item (follow), == 0 means current item.
 	 * @param maxLength The length the branches/paths should try to reach
 	 * @param parentPath The path which lays before the curItem

--- a/testsuite/testcases/src/test/cases/cup2private/edu/tum/cup2/generator/NFA.java
+++ b/testsuite/testcases/src/test/cases/cup2private/edu/tum/cup2/generator/NFA.java
@@ -127,7 +127,7 @@ public class NFA<I extends Item, S extends State<I>>
 	
 	
 	/**
-	 * Pattern: [ srcItem.getPrdocution() ]... | symbol | [ dstItems ]...([ ACCEPT ])
+	 * Pattern: [ srcItem.getProduction() ]... | symbol | [ dstItems ]...([ ACCEPT ])
 	 */
 	@Override
 	public String toString()

--- a/testsuite/testcases/src/test/cases/cup2private/edu/tum/cup2/generator/exceptions/LLkGeneratorException.java
+++ b/testsuite/testcases/src/test/cases/cup2private/edu/tum/cup2/generator/exceptions/LLkGeneratorException.java
@@ -5,7 +5,7 @@ import edu.tum.cup2.generator.LookaheadGenerator;
 
 
 /**
- * Represents an error which occured while running a {@link LLkGenerator}/ {@link LookaheadGenerator}
+ * Represents an error which occurred while running a {@link LLkGenerator}/ {@link LookaheadGenerator}
  * 
  * @author Gero
  * 

--- a/testsuite/testcases/src/test/cases/cup2private/edu/tum/cup2/generator/terminals/TerminalSeq.java
+++ b/testsuite/testcases/src/test/cases/cup2private/edu/tum/cup2/generator/terminals/TerminalSeq.java
@@ -28,7 +28,7 @@ public class TerminalSeq implements ITerminalSeq
 	
 	
 	/**
-	 * The sequence is based on the orderering of the collections iterator
+	 * The sequence is based on the ordering of the collections iterator
 	 * 
 	 * @param terminals
 	 */
@@ -39,7 +39,7 @@ public class TerminalSeq implements ITerminalSeq
 	
 	
 	/**
-	 * The sequence is based on the orderering of the iterator
+	 * The sequence is based on the ordering of the iterator
 	 * 
 	 * @param iterator
 	 */

--- a/testsuite/testcases/src/test/cases/cup2private/edu/tum/cup2/generator/terminals/TerminalSeqSet.java
+++ b/testsuite/testcases/src/test/cases/cup2private/edu/tum/cup2/generator/terminals/TerminalSeqSet.java
@@ -29,7 +29,7 @@ public class TerminalSeqSet implements ITerminalSeqSet
 	
 	
 	/**
-	 * The sequence is based on the orderering of the iterator
+	 * The sequence is based on the ordering of the iterator
 	 * 
 	 * @param sequences
 	 */
@@ -45,7 +45,7 @@ public class TerminalSeqSet implements ITerminalSeqSet
 	
 	
 	/**
-	 * The sequence is based on the orderering of the array
+	 * The sequence is based on the ordering of the array
 	 * 
 	 * @param sequences
 	 */
@@ -61,7 +61,7 @@ public class TerminalSeqSet implements ITerminalSeqSet
 	
 	
 	/**
-	 * The sequence is based on the orderering of the array
+	 * The sequence is based on the ordering of the array
 	 * 
 	 * @param sequences
 	 */

--- a/testsuite/testcases/src/test/cases/cup2private/edu/tum/cup2/generator/terminals/TerminalSeqSetf.java
+++ b/testsuite/testcases/src/test/cases/cup2private/edu/tum/cup2/generator/terminals/TerminalSeqSetf.java
@@ -40,7 +40,7 @@ public class TerminalSeqSetf extends TerminalSeqSet
 	
 	
 	/**
-	 * The sequence is based on the orderering of the iterator
+	 * The sequence is based on the ordering of the iterator
 	 * 
 	 * @param sequences
 	 */
@@ -57,7 +57,7 @@ public class TerminalSeqSetf extends TerminalSeqSet
 	
 	
 	/**
-	 * The sequence is based on the orderering of the array
+	 * The sequence is based on the ordering of the array
 	 * 
 	 * @param sequences
 	 */
@@ -74,7 +74,7 @@ public class TerminalSeqSetf extends TerminalSeqSet
 	
 	
 	/**
-	 * The sequence is based on the orderering of the array
+	 * The sequence is based on the ordering of the array
 	 * 
 	 * @param sequences
 	 */

--- a/testsuite/testcases/src/test/cases/cup2private/edu/tum/cup2/generator/terminals/TerminalSeqf.java
+++ b/testsuite/testcases/src/test/cases/cup2private/edu/tum/cup2/generator/terminals/TerminalSeqf.java
@@ -8,7 +8,7 @@ import edu.tum.cup2.grammar.Terminal;
 import edu.tum.cup2.util.ItIterator;
 
 /**
- * An inmutable implementation of {@link ITerminalSeq}. Mutating methods return new instances.
+ * An immutable implementation of {@link ITerminalSeq}. Mutating methods return new instances.
  * 
  * @author Gero
  * 
@@ -29,7 +29,7 @@ public class TerminalSeqf extends TerminalSeq
 	
 	
 	/**
-	 * The sequence is based on the orderering of the collections iterator
+	 * The sequence is based on the ordering of the collections iterator
 	 * 
 	 * @param terminals
 	 */
@@ -41,7 +41,7 @@ public class TerminalSeqf extends TerminalSeq
 	
 	
 	/**
-	 * The sequence is based on the orderering of the iterator
+	 * The sequence is based on the ordering of the iterator
 	 * 
 	 * @param iterator
 	 */

--- a/testsuite/testcases/src/test/cases/cup2private/edu/tum/cup2/grammar/Production.java
+++ b/testsuite/testcases/src/test/cases/cup2private/edu/tum/cup2/grammar/Production.java
@@ -270,7 +270,7 @@ public final class Production implements Serializable
 	
 	
 	/**
-	 * Returns a list of the the right hand side symbols.
+	 * Returns a list of the right hand side symbols.
 	 */
 	public List<Symbol> getRHS()
 	{

--- a/testsuite/testcases/src/test/cases/cup2private/edu/tum/cup2/parser/LLkParser.java
+++ b/testsuite/testcases/src/test/cases/cup2private/edu/tum/cup2/parser/LLkParser.java
@@ -27,7 +27,7 @@ import edu.tum.cup2.semantics.SymbolValue;
 
 
 /**
- * This class implements a (strong) LL(k)-Parsing pushdown automaton. Its state is representsed by the {@link LLkItem}s
+ * This class implements a (strong) LL(k)-Parsing pushdown automaton. Its state is represented by the {@link LLkItem}s
  * on the {@link #stack} - or a {@link LLkParserState} containing these one (or two) items.
  * 
  * @author Gero

--- a/testsuite/testcases/src/test/cases/cup2private/edu/tum/cup2/parser/tables/ALLkTransitionTable.java
+++ b/testsuite/testcases/src/test/cases/cup2private/edu/tum/cup2/parser/tables/ALLkTransitionTable.java
@@ -17,12 +17,12 @@ public abstract class ALLkTransitionTable
 {
 	/**
 	 * Get the {@link LLkParserState} associated with the given state and symbol. Returns <code>null</code> if no
-	 * appropritate rule is present!
+	 * appropriate rule is present!
 	 * 
 	 * @param from The state...
 	 * @param symbol ... the symbol, and...
 	 * @param lookahead ... the lookahead this method should search the {@link LLkParserState} for
-	 * @return The {@link LLkParserState} associated with the given state and symbol. If theres none, <code>null</code>
+	 * @return The {@link LLkParserState} associated with the given state and symbol. If there's none, <code>null</code>
 	 *         is returned!
 	 */
 	public abstract LLkState getWithNull(LLkState from, Symbol symbol, ITerminalSeq lookahead);

--- a/testsuite/testcases/src/test/cases/cup2private/edu/tum/cup2/parser/tables/LLkTransitionTable.java
+++ b/testsuite/testcases/src/test/cases/cup2private/edu/tum/cup2/parser/tables/LLkTransitionTable.java
@@ -16,7 +16,7 @@ import edu.tum.cup2.parser.states.LLkErrorState;
 
 
 /**
- * This is a sub-table of the {@link LLkParsingTable} for one kind of possbile transitions - expand, shift or reduce.
+ * This is a sub-table of the {@link LLkParsingTable} for one kind of possible transitions - expand, shift or reduce.
  * Here are the {@link LLkTransition}s stored, accessible by {@link LLkState}, current {@link Symbol} and
  * lookahead of length k.<br/>
  * Requests to this table are handled in three stages. The ordering is:<br/>

--- a/testsuite/testcases/src/test/cases/cup2private/edu/tum/cup2/parser/tables/LRActionTable.java
+++ b/testsuite/testcases/src/test/cases/cup2private/edu/tum/cup2/parser/tables/LRActionTable.java
@@ -151,7 +151,7 @@ public class LRActionTable implements Serializable
 	
 	/**
 	 * returns a reference to the internal hashtable containing the semantic actions
-	 * (is is required for testing purposes) 
+	 * (is required for testing purposes) 
 	 */
 	protected Hashtable<StateSymbolKey, LRAction> getTable()
 	{

--- a/testsuite/testcases/src/test/cases/cup2private/edu/tum/cup2/precedences/Precedences.java
+++ b/testsuite/testcases/src/test/cases/cup2private/edu/tum/cup2/precedences/Precedences.java
@@ -7,7 +7,7 @@ import edu.tum.cup2.grammar.Terminal;
 
 
 /**
- * Define the precedences of a grammer.
+ * Define the precedences of a grammar.
  * These are needed for ambiguous grammars to resolve
  * shift-reduce conflicts.
  * 

--- a/testsuite/testcases/src/test/cases/cup2private/edu/tum/cup2/semantics/ErrorInformation.java
+++ b/testsuite/testcases/src/test/cases/cup2private/edu/tum/cup2/semantics/ErrorInformation.java
@@ -229,7 +229,7 @@ public class ErrorInformation implements Serializable {
   
   /**
    * Retrieves information about exact position
-   * where the error occured.
+   * where the error occurred.
    * 
    * @return Line-number of first bad token.
    **/
@@ -239,7 +239,7 @@ public class ErrorInformation implements Serializable {
   }
   /**
    * Retrieves information about exact position
-   * where the error occured.
+   * where the error occurred.
    * 
    * @return Position in line of first bad token (column).
    **/

--- a/testsuite/testcases/src/test/cases/cup2private/edu/tum/cup2/semantics/ParserObserver.java
+++ b/testsuite/testcases/src/test/cases/cup2private/edu/tum/cup2/semantics/ParserObserver.java
@@ -1,7 +1,7 @@
 package edu.tum.cup2.semantics;
 
 /**
- * This inteface may be implemented and used in the context
+ * This interface may be implemented and used in the context
  * of a call to {@link edu.tum.cup2.parser.LRParser#register(ParserObserver)}
  * in order to listen to events created by the parser
  * or by the specification in the form of

--- a/testsuite/testcases/src/test/cases/cup2private/edu/tum/cup2/util/KTreeMap.java
+++ b/testsuite/testcases/src/test/cases/cup2private/edu/tum/cup2/util/KTreeMap.java
@@ -9,7 +9,7 @@ import java.util.Stack;
 /**
  * This class is some kind of {@link Map} implementation based on a tree. For each dimension of the key, there might be
  * a branch with a leaf storing a value. Its special ability is that it matches keys which are shorter then stored ones
- * with the same beginning - but still unambigoius - to the value of the full key. <code>null</code> as key or value is
+ * with the same beginning - but still unambiguous - to the value of the full key. <code>null</code> as key or value is
  * omitted.<br/>
  * <br/>
  * The structure of the tree is as follows:
@@ -204,7 +204,7 @@ public class KTreeMap<K extends Iterable<P>, P, V>
 	
 	/**
 	 * @param key
-	 * @return <code>true</code> if the key matches an unambigious branch in the tree
+	 * @return <code>true</code> if the key matches an unambiguous branch in the tree
 	 */
 	public boolean containsKey(K key)
 	{
@@ -224,7 +224,7 @@ public class KTreeMap<K extends Iterable<P>, P, V>
 	
 	/**
 	 * @param key
-	 * @return <code>true</code> if the key matches an unambigious value-branch in the tree
+	 * @return <code>true</code> if the key matches an unambiguous value-branch in the tree
 	 */
 	public boolean containsValueFor(K key)
 	{
@@ -233,7 +233,7 @@ public class KTreeMap<K extends Iterable<P>, P, V>
 	
 	
 	/**
-	 * Gets a value associated with the given key - or the value which has been put for a unambigious longer key with
+	 * Gets a value associated with the given key - or the value which has been put for a unambiguous longer key with
 	 * the same beginning
 	 * 
 	 * @param key
@@ -280,8 +280,8 @@ public class KTreeMap<K extends Iterable<P>, P, V>
 	
 	
 	/**
-	 * Gets a value associated with the given key, the value which has been put for a unambigious longer key with
-	 * the same beginning, or even the value associated with a shorter key if values are unambigious.
+	 * Gets a value associated with the given key, the value which has been put for a unambiguous longer key with
+	 * the same beginning, or even the value associated with a shorter key if values are unambiguous.
 	 * 
 	 * @param key
 	 * @return See above

--- a/testsuite/testcases/src/test/cases/cup2private/edu/tum/cup2/util/Tuple2.java
+++ b/testsuite/testcases/src/test/cases/cup2private/edu/tum/cup2/util/Tuple2.java
@@ -6,7 +6,7 @@ package edu.tum.cup2.util;
  * to one instance.
  * 
  * This is especially useful for multiple return values.
- * Even more, tupel identity is defined semantically rather than
+ * Even more, tuple identity is defined semantically rather than
  * instance based - we combine the hash-values of e1 and e2 therefore.
  * 
  * @author Andreas Wenger

--- a/testsuite/testcases/src/test/cases/simple/Yylex.java
+++ b/testsuite/testcases/src/test/cases/simple/Yylex.java
@@ -401,7 +401,7 @@ public class Yylex {
 
 
   /**
-   * Reports an error that occured while scanning.
+   * Reports an error that occurred while scanning.
    *
    * In a wellformed scanner (no or only correct usage of 
    * yypushback(int) and a match-all fallback rule) this method 
@@ -781,7 +781,7 @@ public class Yylex {
    *
    * This main method is the debugging routine for the scanner.
    * It prints debugging information about each returned token to
-   * System.out until the end of file is reached, or an error occured.
+   * System.out until the end of file is reached, or an error occurred.
    *
    * @param argv   the command line, contains the filenames to run
    *               the scanner on.


### PR DESCRIPTION
Hi, while fixing some spelling mistakes in the lucene-solr project, I noticed that some were originating from jflex. So removed the corrections from the Java files in lucene-solr, but thought it would be worth submitting a pull request here too just in case?

This pull request fixes some minor spelling mistakes found in Java files.

Before the changes, `run-tests` reports 1 failure. After the changes, it reports the same test failing. Had a look but without knowing much about jflex, it wasn't clear how the test could be fixed, sorry.

Hope it helps
Bruno