### PR TITLE
Configure Travis to use openjdk

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 
 jdk:
-  - oraclejdk7
+  - openjdk7
 
 script: ./run-tests


### PR DESCRIPTION
Travis doesn't support oracle JDK anymore. See https://github.com/travis-ci/travis-ci/issues/7884
Use openjdk7 instead of oraclejdk7.

Fix #220 