### PR TITLE
Fix FindBugs issues

### DIFF
--- a/jflex-unicode-maven-plugin/src/main/java/jflex/DerivedAgeScanner.java
+++ b/jflex-unicode-maven-plugin/src/main/java/jflex/DerivedAgeScanner.java
@@ -1,6 +1,7 @@
 package jflex;
 
 import java.io.Reader;
+import java.util.Map.Entry;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.regex.Matcher;
@@ -65,14 +66,14 @@ public class DerivedAgeScanner extends EnumeratedPropertyFileScanner {
     }
     
     String previousVersion = null;
-    for (String version : ageRangesPerVersion.keySet()) {
-      NamedRangeSet targetRanges = ageRangesPerVersion.get(version);
+    for (Entry<String, NamedRangeSet> entry : ageRangesPerVersion.entrySet()) {
+      NamedRangeSet targetRanges = entry.getValue();
       if (null != previousVersion) {
         // Add previous version's ranges to the next version's
         targetRanges.add(ageRangesPerVersion.get(previousVersion));
       }
-      previousVersion = version;
-      String age = getAge(version);
+      previousVersion = entry.getKey();
+      String age = getAge(entry.getKey());
       for (NamedRange range : targetRanges.getRanges()) {
         unicodeVersion.addInterval(propertyName, age, range.start, range.end);
       }

--- a/jflex-unicode-maven-plugin/src/main/java/jflex/NamedRange.java
+++ b/jflex-unicode-maven-plugin/src/main/java/jflex/NamedRange.java
@@ -29,9 +29,9 @@ public class NamedRange implements Comparable<NamedRange> {
   public int compareTo(NamedRange other) {
     int comparison = 0;
     if (null != other) {
-      comparison = (new Integer(start)).compareTo(other.start);
+      comparison = Integer.valueOf(start).compareTo(other.start);
       if (0 == comparison) {
-        comparison = (new Integer(end)).compareTo(other.end);
+        comparison = Integer.valueOf(end).compareTo(other.end);
       }
     }
     return comparison;

--- a/jflex-unicode-maven-plugin/src/main/java/jflex/UnicodePropertiesSkeleton.java
+++ b/jflex-unicode-maven-plugin/src/main/java/jflex/UnicodePropertiesSkeleton.java
@@ -82,24 +82,25 @@ public class UnicodePropertiesSkeleton {
     }
     String line;
     StringBuilder section = new StringBuilder();
-    BufferedReader reader = new BufferedReader
-      (new InputStreamReader(url.openStream(), "UTF-8"));
-    while (null != (line = reader.readLine())) {
-      if (line.startsWith("---")) {
-        sections.add(section.toString());
-        section.setLength(0);
-      } else {
-        section.append(line);
-        section.append(NL);
+    try (BufferedReader reader = new BufferedReader
+      (new InputStreamReader(url.openStream(), "UTF-8"))) {
+      while (null != (line = reader.readLine())) {
+        if (line.startsWith("---")) {
+          sections.add(section.toString());
+          section.setLength(0);
+        } else {
+          section.append(line);
+          section.append(NL);
+        }
       }
-    }
-    if (section.length() > 0) {
-      sections.add(section.toString());
-    }
-    if (sections.size() != size) {
-      throw new Exception("Skeleton file '" + skeletonFilename + "' has "
-                          + sections.size() + " static sections, but " + size
-                          + " were expected.");
+      if (section.length() > 0) {
+        sections.add(section.toString());
+      }
+      if (sections.size() != size) {
+        throw new Exception("Skeleton file '" + skeletonFilename + "' has "
+                            + sections.size() + " static sections, but " + size
+                            + " were expected.");
+      }
     }
   }
 }

--- a/testsuite/jflex-testsuite-maven-plugin/src/main/java/jflextest/CustomClassLoader.java
+++ b/testsuite/jflex-testsuite-maven-plugin/src/main/java/jflextest/CustomClassLoader.java
@@ -165,8 +165,7 @@ public class CustomClassLoader extends ClassLoader {
    * Return InputStream for a jar/zip file entry.
    */
   private InputStream getZipEntryStream(String file, String entryName) {
-    try {
-      ZipFile zip = new ZipFile(new File(file));
+    try (ZipFile zip = new ZipFile(new File(file))) {
       ZipEntry entry = zip.getEntry(entryName);
 
       if (entry == null) return null;

--- a/testsuite/jflex-testsuite-maven-plugin/src/main/java/jflextest/DiffStream.java
+++ b/testsuite/jflex-testsuite-maven-plugin/src/main/java/jflextest/DiffStream.java
@@ -55,7 +55,7 @@ class DiffStream {
 					return "EOF reached in Input(Line:"+linesProcessed+")... more Lines expected.\n";
 				}
         if (readFromInput != null && !match(readFromInput,readFromExpected)) {
-          if (!diffLines.contains(new Integer(linesProcessed)))
+          if (!diffLines.contains(Integer.valueOf(linesProcessed)))
             return "Difference in line "+linesProcessed+"\n"+
                    "expected :["+readFromExpected+"]\n"+
                    "but got  :["+readFromInput+"]";


### PR DESCRIPTION
- Performance: Inefficient map iterator
  Improve loops on maps by reading the entry, rather than the key and then the value
- Use AutoClosable
- Performance: Use Integer.valueOf() instead of creating new Integer objects

```
mvn clean
mvn -N install
mvn package findbugs:findbugs
```