### PR TITLE
Improve run-tests.sh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,5 @@ jdk:
   - openjdk7
   - openjdk8
 
-script: ./run-tests
+script: ./run-tests --travis
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,5 @@ jdk:
   - openjdk7
   - openjdk8
 
-script: ./run-tests --travis
+script: ./run-tests
 

--- a/run-tests
+++ b/run-tests
@@ -1,20 +1,12 @@
 #!/bin/bash
 
-# Travis already runs Maven, and invokes the script with
-# ./run-tests --travis
-RUN_LOCAL=true
-while true
-do
-  case $1 in
-    --travis) RUN_LOCAL=false ; shift ;;
-    *) break ;;
-  esac
-done
-
 # fail on error
 set -e
 
-if [[ $RUN_LOCAL ]]; then
+if [[ ! $TRAVIS ]]; then
+  echo "[INFO] Applying steps executed by Travis"
+  echo "[INFO] See https://docs.travis-ci.com/user/languages/java/#Projects-Using-Maven"
+  sleep 2
   # clean existing artefacts
   # note that mvn could fail if POM are incorrects
   find . -name target -type d -delete

--- a/run-tests
+++ b/run-tests
@@ -1,26 +1,51 @@
 #!/bin/bash
 
-# build all projects and run tests
+# Travis already runs Maven, and invokes the script with
+# ./run-tests --travis
+RUN_LOCAL=true
+while true
+do
+  case $1 in
+    --travis) RUN_LOCAL=false ; shift ;;
+    *) break ;;
+  esac
+done
 
 # fail on error
 set -e
 
-# builds and tests main projects
-mvn clean install test
+if [[ $RUN_LOCAL ]]; then
+  # clean existing artefacts
+  # note that mvn could fail if POM are incorrects
+  find . -name target -type d -delete
 
-# regression test suite must run from its own directory
+  # Travis installs dependencies
+  # https://docs.travis-ci.com/user/languages/java/#Projects-Using-Maven
+  mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
+
+  # build and tests main projects
+  mvn test -B
+fi
+
+# Install jflex in local repo
+# implies: validate, compile, test, package, verify
+mvn install
+
+# regression test suite must run in its own directory
 cd testsuite/testcases && mvn test
+cd ../..
 
 # also check ant build
-cd ../../jflex && ant gettools build test
+cd jflex && ant gettools build test
+cd ..
 
 ## run jflex examples:
-
+cd jflex/examples
 # don't assume byacc/j is installed, just run lexer
-cd examples/byaccj && make clean && make Yylex.java
-cd ../cup && make clean && make
-cd ../interpreter && make clean && make
-cd ../java && make clean && make
-cd ../simple-maven && mvn clean test
-cd ../standalone-maven && mvn clean test
-cd ../zero-reader && make clean && make
+cd byaccj && make clean && make Yylex.java && cd ..
+cd cup && make clean && make && cd ..
+cd interpreter && make clean && make && cd ..
+cd java && make clean && make && cd ..
+cd simple-maven && mvn clean test && cd ..
+cd standalone-maven && mvn clean test && cd ..
+cd zero-reader && make clean && make && cd ..


### PR DESCRIPTION
Travis starts builds in a new container and already compiles everything from scratch.
There is no need to `mvn clean`.

However, if the `$TRAVIS` environment variable is not defined, the script will mimic everything Travis does by default.
