### PR TITLE
Update address of central Maven repo in ant script

### DIFF
--- a/jflex/build.xml
+++ b/jflex/build.xml
@@ -23,7 +23,7 @@
   <property name="junit.jar" value="${lib.dir}/junit-${junit.version}.jar" />
 
   <!-- where to get tool jars from -->
-  <property name="maven.central.url" value="http://central.maven.org/maven2" />
+  <property name="maven.central.url" value="https://repo.maven.apache.org/maven2" />
   <property name="bootstrap.jflex.jar.url" 
   	        value="${maven.central.url}/de/jflex/jflex/${bootstrap.version}/jflex-${bootstrap.version}.jar" />
   <property name="junit.jar.url"


### PR DESCRIPTION
The central.maven.org has been replaced by repo.maven.apache.org