### PR TITLE
Let Travis fail if a test fail

### DIFF
--- a/jflex/examples/cup/Makefile
+++ b/jflex/examples/cup/Makefile
@@ -1,8 +1,7 @@
 JAVA=java
 JAVAC=javac
 # Root of the project
-# regis Wrong on purpose, I want to see Travis fail
-ROOT=../..
+ROOT=../../..
 JFLEX=$(ROOT)/jflex/bin/jflex
 CUPJAR=$(ROOT)/cup/cup/java-cup-11b.jar
 CUP=$(JAVA) -jar $(CUPJAR) <

--- a/jflex/examples/cup/Makefile
+++ b/jflex/examples/cup/Makefile
@@ -2,8 +2,8 @@ JAVA=java
 JAVAC=javac
 # Root of the project
 ROOT=../../..
-JFLEX=$ROOT/jflex/bin/jflex
-CUPJAR=$ROOT/cup/cup/java-cup-11b.jar
+JFLEX=$(ROOT)/jflex/bin/jflex
+CUPJAR=$(ROOT)/cup/cup/java-cup-11b.jar
 CUP=$(JAVA) -jar $(CUPJAR) <
 CP=.:$(CUPJAR)
 

--- a/jflex/examples/cup/Makefile
+++ b/jflex/examples/cup/Makefile
@@ -1,7 +1,8 @@
 JAVA=java
 JAVAC=javac
 # Root of the project
-ROOT=../../..
+# regis Wrong on purpose, I want to see Travis fail
+ROOT=../..
 JFLEX=$(ROOT)/jflex/bin/jflex
 CUPJAR=$(ROOT)/cup/cup/java-cup-11b.jar
 CUP=$(JAVA) -jar $(CUPJAR) <

--- a/jflex/examples/interpreter/Makefile
+++ b/jflex/examples/interpreter/Makefile
@@ -13,8 +13,8 @@ JAVA=java
 JAVAC=javac
 # Root of the project
 ROOT=../../..
-JFLEX=$ROOT/jflex/bin/jflex
-CUPJAR=$ROOT/cup/cup/java-cup-11b.jar
+JFLEX=$(ROOT)/jflex/bin/jflex
+CUPJAR=$(ROOT)/cup/cup/java-cup-11b.jar
 CUP=$(JAVA) -jar $(CUPJAR)
 CP=.:$(CUPJAR)
 

--- a/jflex/examples/java/Makefile
+++ b/jflex/examples/java/Makefile
@@ -5,8 +5,8 @@
 CUP        = java java_cup.Main -interface <
 # Root of the project
 ROOT       = ../../..
-JFLEX      = $ROOT/jflex/bin/jflex
-CUPJAR     = $ROOT/cup/cup/java-cup-11b.jar
+JFLEX      = $(ROOT)/jflex/bin/jflex
+CUPJAR     = $(ROOT)/cup/cup/java-cup-11b.jar
 CP         = .:$(CUPJAR)
 JAVA       = java
 JAVAC      = javac

--- a/run-tests
+++ b/run-tests
@@ -31,14 +31,21 @@ cd ../..
 
 ## run jflex examples:
 cd jflex/examples
+cd simple-maven && mvn test
+cd ..
+cd standalone-maven && mvn test
+cd ..
 # don't assume byacc/j is installed, just run lexer
-cd byaccj && make clean && make Yylex.java && cd ..
-cd cup && make clean && make && cd ..
-cd interpreter && make clean && make && cd ..
-cd java && make clean && make && cd ..
-cd simple-maven && mvn clean test && cd ..
-cd standalone-maven && mvn clean test && cd ..
-cd zero-reader && make clean && make && cd ..
+cd byaccj && make clean && make Yylex.java
+cd ..
+cd cup && make clean && make
+cd ..
+cd interpreter && make clean && make
+cd ..
+cd java && make clean && make
+cd ..
+cd zero-reader && make clean && make
+cd ..
 
 # also check ant build
 cd jflex && ant gettools build test

--- a/run-tests
+++ b/run-tests
@@ -29,7 +29,9 @@ fi
 cd testsuite/testcases && ../../mvnw test
 cd ../..
 
-## run jflex examples:
+## run jflex examples
+# Each line must end with the test command to make the script exit
+# in case of error (see #242)
 cd jflex/examples
 cd simple-maven && mvn test
 cd ..


### PR DESCRIPTION
`set -e`: Exit immediately if a command exits with a non-zero status.

However
> the shell does not exit if the command that fails is part of the command list immediately following a while or until keyword, part of the test in an if statement, **part of any command executed in a && or ||** list except the command following the final && or ||, any command in a pipeline but the last, or if the command’s return status is being inverted with !. 

https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html

Hence ending the execution of the test with `&& cd ..` prevents the exit of the script in case of failure.

Change to parent directory on its own line.

Fix #242 