### PR TITLE
run-tests: Support path with space

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,4 @@ jdk:
 
 script: ./scripts/run-tests.sh
 
+installation: true

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -47,7 +47,7 @@ fi
 
 logi "Run regression test cases"
 # regression test suite must run in its own directory
-cd testsuite/testcases; ../."$MVN" test
+cd testsuite/testcases; "$MVN" test
 cd ../..
 
 logi "Run jflex examples"

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -2,18 +2,20 @@
 
 # Multi-platform hack for:
 #SCRIPT_PATH=$(dirname "$(readlink -f $0)")
-CWD=$PWD
+CWD="$PWD"
 SCRIPT_PATH="$(cd "$(dirname "$0")" && pwd -P)"
-cd $CWD
+cd "$CWD"
 
 # Provides the logi function
-source $SCRIPT_PATH/logger.sh
+source "$SCRIPT_PATH"/logger.sh
+
+MVN="$SCRIPT_PATH"/../mvnw
 
 # fail on error
 set -e
 
 logi "Powered by Maven wrapper"
-./mvnw --version
+"$MVN" --version
 
 if [[ ! $TRAVIS ]]; then
   # clean existing artefacts
@@ -26,7 +28,7 @@ if [[ ! $TRAVIS ]]; then
 
   # Travis installs dependencies
   #mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
-  #./mvnw install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
+  #"$MVN" install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
   # Skipped because .travis.yml has `installation: true`
 
   # Travis runs tests
@@ -36,11 +38,11 @@ fi
 logi "Compile and install all"
 # Install jflex in local repo
 # implies: validate, compile, test, package, verify
-./mvnw install
+"$MVN" install
 
 logi "Run regression test cases"
 # regression test suite must run in its own directory
-cd testsuite/testcases; ../../mvnw test
+cd testsuite/testcases; ../."$MVN" test
 cd ../..
 
 logi "Run jflex examples"
@@ -48,6 +50,7 @@ logi "Run jflex examples"
 # in case of error (see #242)
 cd jflex/examples
 cd simple-maven; mvn test; cd ..
+# Note that mvn is a likely to be a different and older version of Maven.
 cd standalone-maven; mvn test; cd ..
 # don't assume byacc/j is installed, just run lexer
 cd byaccj; make clean; make Yylex.java; cd ..

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -37,8 +37,13 @@ fi
 
 logi "Compile and install all"
 # Install jflex in local repo
-# implies: validate, compile, test, package, verify
-"$MVN" install
+# implies: validate, compile, test, package, verify, install
+if [[ $TRAVIS ]]; then
+  # Quiet mode shows errors only.
+  "$MVN" install --quiet
+else
+  "$MVN" install
+fi
 
 logi "Run regression test cases"
 # regression test suite must run in its own directory


### PR DESCRIPTION
* Support path with space
  Use absolute MVN path wwrapped in `""` to support directory names with space.
* Speed up the build
  Also, speed up the build by telling Travis to not install dependencies. Maven already does it automatically. 
* Make build logs more synthetic
  - Make the build quiet when running on Travis (this strips all the "Downloading..." lines in the log).   
    This also strips other build info and warnings.
    Errors are still in the logs, of course.
  - When executed locally, the Maven logs are still verbose
