### PR TITLE
Simplify profiles

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -358,6 +358,17 @@
 
   <profiles>
     <profile>
+      <id>no-doclint</id>
+      <activation>
+        <property>
+          <name>!env.CI</name>
+        </property>
+      </activation>
+      <properties>
+        <javadoc.opts>-Xdoclint:none</javadoc.opts>
+      </properties>
+    </profile>
+    <profile>
       <id>error-prone</id>
       <activation>
         <jdk>[1.8,)</jdk>
@@ -391,34 +402,7 @@
               </dependency>
             </dependencies>
           </plugin>
-          <plugin>
-            <artifactId>maven-javadoc-plugin</artifactId>
-            <configuration>
-              <additionalparam>-Xdoclint:none</additionalparam>
-            </configuration>
-          </plugin>
-          <plugin>
-            <artifactId>maven-site-plugin</artifactId>
-            <configuration>
-              <reportPlugins>
-                <plugin>
-                  <configuration>
-                    <additionalparam>-Xdoclint:none</additionalparam>
-                  </configuration>
-                </plugin>
-              </reportPlugins>
-            </configuration>
-          </plugin>
         </plugins>
-        <pluginManagement>
-          <plugins>
-            <plugin>
-              <groupId>com.coveo</groupId>
-              <artifactId>fmt-maven-plugin</artifactId>
-              <version>2.1.0</version>
-            </plugin>
-          </plugins>
-        </pluginManagement>
       </build>
     </profile>
     <profile>


### PR DESCRIPTION
- fmt plugin has nothing to do in error-prone
- disabling doclint can be made in an easier way
- disabling doclint onlyon CI server