### PR TITLE
Use maven-project-info-reports-plugin 2.2

### DIFF
--- a/cup/pom.xml
+++ b/cup/pom.xml
@@ -78,10 +78,6 @@
           <version>2.5.2</version>
         </plugin>
         <plugin>
-          <artifactId>maven-project-info-reports-plugin</artifactId>
-          <version>2.9</version>
-        </plugin>
-        <plugin>
           <artifactId>maven-resources-plugin</artifactId>
           <version>2.6</version>
           <configuration>

--- a/cup/pom.xml
+++ b/cup/pom.xml
@@ -79,7 +79,7 @@
         </plugin>
         <plugin>
           <artifactId>maven-project-info-reports-plugin</artifactId>
-          <version>3.0.0</version>
+          <version>2.9</version>
         </plugin>
         <plugin>
           <artifactId>maven-resources-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -316,6 +316,9 @@
     <plugins>
       <plugin>
         <artifactId>maven-project-info-reports-plugin</artifactId>
+        <!-- Use a version compatible with maven 3
+             https://maven.apache.org/plugins/maven-site-plugin/maven-3.html -->
+        <version>2.2</version>
         <reportSets>
           <reportSet>
             <reports>


### PR DESCRIPTION
That's the only supported version for Maven 3
https://maven.apache.org/plugins/maven-site-plugin/maven-3.html

Also revert  "Update maven-project-info-reports-plugin to version 3.0.0 (commit 39f4e04) which had no effect.

Fix #280 