### PR TITLE
Cache the .m2/repository

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,20 @@ env:
   - TEST_SUITE=unit
   - TEST_SUITE=regression
 
+# Travis sometimes fails to download deps from repo1.maven.org
+# A cache avoids downloading too much, and will also speed up the build.
+# NB: There is one cache per branch and language version/ compiler version/ JDK version
+cache:
+  # The timeout (in seconds) empties the cache to avoid being stuck with a corrupted artefact
+  timeout: 86400  # 24 hours
+  directories:
+  - $HOME/.m2
+
+# Empty our own artefacts from the cache. Those need to be build and installed.
+before_cache:
+  - rm -rf $HOME/.m2/repository/de/jflex
+
+# Build the maven site
 before_deploy: ./scripts/before-deploy.sh
 
 deploy:


### PR DESCRIPTION
This will
- make the build more reliale – sometimes, Travis fails to download artefacts
- make the build faster

NB There is one cache per cell in the build matrix (for jdk / env) and per branch