### PR TITLE
Cache .m2/repository [roll forward]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ cache:
   timeout: 86400  # 24 hours
   directories:
   - $HOME/.m2
+  - jflex/lib
 
 # Empty our own artifacts from the cache. Those need to be build and installed.
 before_cache: ./scripts/clean.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,8 @@ cache:
   directories:
   - $HOME/.m2
 
-# Empty our own artefacts from the cache. Those need to be build and installed.
-before_cache:
-  - find $HOME/.m2/repository/de/jflex -name '*-SNAPSHOT.*' -exec rm -rf {} \; || true
+# Empty our own artifacts from the cache. Those need to be build and installed.
+before_cache: ./scripts/clean.sh
 
 # Build the maven site
 before_deploy: ./scripts/before-deploy.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ cache:
 
 # Empty our own artefacts from the cache. Those need to be build and installed.
 before_cache:
-  - rm -rf $HOME/.m2/repository/de/jflex
+  - find $HOME/.m2/repository/de/jflex -name '*-SNAPSHOT.*' -exec rm -rf {} \; || true
 
 # Build the maven site
 before_deploy: ./scripts/before-deploy.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,20 @@ env:
   - TEST_SUITE=unit
   - TEST_SUITE=regression
 
+# Travis sometimes fails to download deps from repo1.maven.org
+# A cache avoids downloading too much, and will also speed up the build.
+# NB: There is one cache per branch and language version/ compiler version/ JDK version
+cache:
+  # The timeout (in seconds) empties the cache to avoid being stuck with a corrupted artefact
+  timeout: 86400  # 24 hours
+  directories:
+  - $HOME/.m2
+
+# Empty our own artefacts from the cache. Those need to be build and installed.
+before_cache:
+  - rm -rf $HOME/.m2/repository/de/jflex
+
+# Build the maven site
 before_deploy: ./scripts/before-deploy.sh
 
 deploy:

--- a/jflex/build.xml
+++ b/jflex/build.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0"?>
 <project name="JFlex" default="help">
 
+  <property environment="env" />
+
   <property name="version" value="1.7.0-SNAPSHOT" />
   <property name="bootstrap.version" value="1.6.1" />
   <property name="junit.version" value="4.11" />
@@ -13,9 +15,10 @@
   <!-- use any of these files to override properties -->
   <property file="build.properties" />
   <property file="${user.home}/.jflex.properties" />
-  
+
   <!-- location of development tools necessary for the build -->
   <property name="lib.dir" value="lib"/>
+  <property name="m2repo" value="${env.HOME}/.m2/repository" />
     
   <!-- override these if you want to use your own versions -->
   <property name="bootstrap.jflex.jar" value="${lib.dir}/jflex-${bootstrap.version}.jar" />
@@ -24,10 +27,8 @@
 
   <!-- where to get tool jars from -->
   <property name="maven.central.url" value="https://repo.maven.apache.org/maven2" />
-  <property name="bootstrap.jflex.jar.url" 
-  	        value="${maven.central.url}/de/jflex/jflex/${bootstrap.version}/jflex-${bootstrap.version}.jar" />
-  <property name="junit.jar.url"
-            value="${maven.central.url}/junit/junit/${junit.version}/junit-${junit.version}.jar" />
+  <property name="bootstrap.jflex.jar.path" value="de/jflex/jflex/${bootstrap.version}/jflex-${bootstrap.version}.jar" />
+  <property name="junit.jar.path" value="junit/junit/${junit.version}/junit-${junit.version}.jar" />
 
   <!-- where build output goes, including the jflex jar -->
   <property name="build.dir" value="build"/>
@@ -60,9 +61,10 @@
   </target> 
 
   <target name="gettools" description="download development tools">
-    <get src="${bootstrap.jflex.jar.url}" dest="${bootstrap.jflex.jar}"/>
-    <get src="${junit.jar.url}" dest="${junit.jar}"/>
-    <copy file="../cup/cup/java-cup-${cup.version}.jar" todir="${lib.dir}" />
+    <!-- Download libs from central Maven repo otherwise. -->
+    <get src="${maven.central.url}/${bootstrap.jflex.jar.path}" dest="${bootstrap.jflex.jar}" skipexisting="true"/>
+    <get src="${maven.central.url}/${junit.jar.path}" dest="${junit.jar}" skipexisting="true"/>
+    <copy file="../cup/cup/java-cup-${cup.version}.jar" todir="${lib.dir}" overwrite="false"/>
   </target>
 
   <target name="build" depends="clean,jar" 

--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -7,9 +7,12 @@ source "$BASEDIR"/scripts/logger.sh
 logi "Clean the environment"
 logi "====================="
 
-# Cleanup up Maven targets
+# Clean up all Maven targets
 # note that Maven could fail if POM are incorrect
 find "$BASEDIR" -name target -type d -exec rm -rf {} \; || true
 
-# Clean up local maven repo
+# Clean up SNAPSHOT in ant lib
+find "$BASEDIR/jflex/lib" -name '*-SNAPSHOT.*' -exec rm -rf {} \; || true
+
+# Clean up SNAPSHOT in local maven repo
 find ~/.m2/repository/de/jflex -name '*-SNAPSHOT.*' -exec rm -rf {} \; || true

--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+BASEDIR="$(cd "$(dirname "$0")" && pwd -P)"/..
+# Provides the logi function
+source "$BASEDIR"/scripts/logger.sh
+
+logi "Clean the environment"
+logi "====================="
+
+# Cleanup up Maven targets
+# note that Maven could fail if POM are incorrect
+find "$BASEDIR" -name target -type d -exec rm -rf {} \; || true
+
+# Clean up local maven repo
+find ~/.m2/repository/de/jflex -name '*-SNAPSHOT.*' -exec rm -rf {} \; || true

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -16,13 +16,7 @@ echo '==========================================================================
 
 # Clean environment
 if [[ ! $TRAVIS ]]; then
-  logi "Clean up environment"
-  # Cleanup up Maven targets
-  # note that Maven could fail if POM are incorrect
-  find "$BASEDIR" -name target -type d -exec rm -rf {} \; || true
-
-  # Clean up local maven repo
-  find ~/.m2/repository/de/jflex -name '*-SNAPSHOT.*' -exec rm -rf {} \; || true
+  "$BASEDIR"/scripts/clean.sh
 fi
 
 # Travis then runs _in parallel_ (but we do it in sequence)

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -24,9 +24,6 @@ if [[ ! $TRAVIS ]]; then
   # Clean up local maven repo
   # TODO: This could be changed with ~/.m2/settings.xml
   rm -rf "$HOME"/.m2/repository/de/jfex || true
-
-  logi "Remove jflex.jar in lib directory"
-  rm "$BASEDIR"/jflex/lib/jflex-*.jar || true
 fi
 
 # Travis then runs _in parallel_ (but we do it in sequence)

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -22,8 +22,7 @@ if [[ ! $TRAVIS ]]; then
   find "$BASEDIR" -name target -type d -exec rm -rf {} \; || true
 
   # Clean up local maven repo
-  # TODO: This could be changed with ~/.m2/settings.xml
-  rm -rf "$HOME"/.m2/repository/de/jfex || true
+  find ~/.m2/repository/de/jflex -name '*-SNAPSHOT.*' -exec rm -rf {} \; || true
 fi
 
 # Travis then runs _in parallel_ (but we do it in sequence)

--- a/scripts/test-unit.sh
+++ b/scripts/test-unit.sh
@@ -10,6 +10,12 @@ MVN="$BASEDIR"/mvnw
 # fail on error
 set -e
 
+# Work around
+# The following artifacts could not be resolved: de.jflex:cup:jar:11b, de.jflex:cup_runtime:jar:11b
+logi "Compile, test and install CUP"
+logi "============================="
+"$MVN" -pl cup,cup/cup,cup/cup_runtime install
+
 logi "Compile, test and install all"
 logi "============================="
 # NB: Installs jflex in local repo


### PR DESCRIPTION
Roll forward commit 2c10923e17b401d37a0224c2aa43855f0596cc36 (#296)

For some reason `mvn install` now fails to install `cup` and `cup_runtime`. Update the script to install those explicitly first.
