### PR TITLE
Use UTF-8 encoding in example projects

### DIFF
--- a/jflex/examples/cup-maven/pom.xml
+++ b/jflex/examples/cup-maven/pom.xml
@@ -82,4 +82,7 @@
       </plugin>
     </plugins>
   </build>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
 </project>

--- a/jflex/examples/simple-maven/pom.xml
+++ b/jflex/examples/simple-maven/pom.xml
@@ -35,4 +35,7 @@
       </plugin>
     </plugins>
   </build>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
 </project>

--- a/jflex/examples/standalone-maven/pom.xml
+++ b/jflex/examples/standalone-maven/pom.xml
@@ -32,4 +32,7 @@ of "hello" by "hello <name> !".]]></description>
       </plugin>
     </plugins>
   </build>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
 </project>


### PR DESCRIPTION
Fixes [WARNING] Using platform encoding (UTF-8 actually) to copy filtered resources, i.e. build is platform dependent!

See #164