### PR TITLE
Let Travis update the aggregated-java-sources branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,17 +1,24 @@
 *~
+*.versionsBackup
+
 *.class
+
+# Build artefacts
+**/target
+dependency-reduced-pom.xml
+
+# IntelliJ
 *.iml
 *.ipr
 *.iws
 .idea
-*.versionsBackup
-
-**/target
-
-dependency-reduced-pom.xml
 
 # Eclipse project
 .project
 .classpath
 .metadata/
 .settings/
+
+# aggregated-java-source repository
+repo
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,9 @@ install: true
 
 script: ./scripts/run-tests.sh
 
+after_success:
+  - ./scripts/desploy-source-code.sh
+
 env:
   matrix:
   - TEST_SUITE=ant

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@
 branches:
   only:
   - master
+  - aggregated-java-sources
 
 language: java
 

--- a/scripts/deploy-source-code.sh
+++ b/scripts/deploy-source-code.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+# Push aggregated source code back to git
+# This is inspired by https://martinrotter.github.io/it-programming/2016/08/26/pushing-git-travis/
+
+CWD="$PWD"
+BASEDIR="$(cd "$(dirname "$0")" && pwd -P)"/..
+# Provides the logi function
+source "$BASEDIR"/scripts/logger.sh
+# fail on error
+set -e
+
+git_setup() {
+  git config --global user.name "Travis CI"
+  git config --global user.email "deploy@travis-ci.org"
+}
+
+git_clone() {
+  logi "Cloning https://github.com/jflex-de/jflex/tree/aggregated-java-sources"
+  git clone --depth 1 --branch aggregated-java-sources https://github.com/jflex-de/jflex.git repo
+}
+
+update_source() {
+  version=$(ls target/jflex-*-sources.jar)
+  logi "Updating sources from $version"
+  cd repo
+  git rm -r META-INF jflex java_cup UnicodeProperties.java.skeleton
+  jar -xf ../target/jflex-*-sources.jar
+  logi "Remove unrelated sources and compile"
+  ./compile.sh
+  git add --all
+  git commit -a -m "Update from $version"
+  cd ..
+}
+
+git_push() {
+  cd repo
+  logi "Git log"
+  git --no-pager log
+  git diff --name-only HEAD^1
+  logi "Push to https://github.com/jflex-de/jflex/tree/aggregated-java-sources"
+  git push
+  cd ..
+}
+
+if [ -z "$CI" ] || [ "_$TEST_SUITE" -eq "_unit" ]; then
+  git_setup
+  git_clone
+  update_source
+fi
+
+# Travis should only push from master ; not from pull requests
+if [ "_$TEST_SUITE" -eq "_unit" ] && [ "_$(git rev-parse --abbrev-ref HEAD)" -eq "_master" ]; then
+  git_push
+fi

--- a/scripts/test-unit.sh
+++ b/scripts/test-unit.sh
@@ -48,4 +48,6 @@ logi "Example: zero-reader"
 cd zero-reader; make clean; make; cd ..
 set +x
 
+"$MVN" source:aggregate
+
 cd "$CWD"


### PR DESCRIPTION
We now have a branch [aggregated-java-sources](https://github.com/jflex-de/jflex/tree/aggregated-java-sources).

With this change, Travis will push the java sources of jflex (incl. generated-sources) on every commit on **master**.
