### PR TITLE
Minor: Udpate Windows batch script

### DIFF
--- a/jflex/bin/jflex.bat
+++ b/jflex/bin/jflex.bat
@@ -5,4 +5,4 @@ REM (please do not add a trailing backslash)
 set JFLEX_HOME=C:\JFLEX
 set JFLEX_VERSION=1.7.0-SNAPSHOT
 
-java -Xmx128m -jar %JFLEX_HOME%\lib\jflex-full-%JFLEX_VERSION%.jar %1 %2 %3 %4 %5 %6 %7 %8 %9
+java -Xmx128m -jar "%JFLEX_HOME%"\lib\jflex-full-%JFLEX_VERSION%.jar %*


### PR DESCRIPTION
Use `%*` for remaining args, instead of `%1` `%2` `%3` ... `%9`
(which might me a couple)
