### PR TITLE
Use Maven wrapper in deploy script

### DIFF
--- a/mvn-deploy.sh
+++ b/mvn-deploy.sh
@@ -43,5 +43,7 @@ cd ../jflex-maven-plugin
 
 # Deploy the deployable stuff to the Sonatype OSS Maven repository
 cd ..
-mvn deploy
+./mvnw javadoc:jar
+./mvnw source:jar
+./mvnw deploy
 

--- a/mvn-deploy.sh
+++ b/mvn-deploy.sh
@@ -29,17 +29,17 @@ fi
 echo "Yes."
 
 # Install the jflex-parent POM
-mvn -N install
+./mvnw -N install
 
 # Install JFlex
 cd jflex
-mvn clean
-mvn install
+../mvnw clean
+../mvnw install
 
 # Install the JFlex Maven Plugin
 cd ../jflex-maven-plugin
-mvn clean
-mvn install
+../mvnw clean
+../mvnw install
 
 # Deploy the deployable stuff to the Sonatype OSS Maven repository
 cd ..


### PR DESCRIPTION
- Prefer `mvnw` over `mvn`
- Also build the javadoc and source jars before deploy. Fix #315
