### PR TITLE
Fix typo when calling deploy-source-code.sh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ install: true
 script: ./scripts/run-tests.sh
 
 after_success:
-  - ./scripts/desploy-source-code.sh
+  - ./scripts/deploy-source-code.sh
 
 env:
   matrix:

--- a/scripts/deploy-source-code.sh
+++ b/scripts/deploy-source-code.sh
@@ -9,7 +9,6 @@ source "$BASEDIR"/scripts/logger.sh
 # fail on error
 set -e
 
-
 git_clone() {
   logi "Cloning https://github.com/jflex-de/jflex/tree/aggregated-java-sources"
   git clone --depth 1 --branch aggregated-java-sources https://github.com/jflex-de/jflex.git repo
@@ -39,7 +38,6 @@ git_push() {
 }
 
 current_branch=$(git rev-parse --abbrev-ref HEAD)
-logi "CI=$CI TEST_SUITE=$TEST_SUITE JDK=$TRAVIS_JDK_VERSION branch=$current_branch"
 
 if [ -z "$CI" ] || \
     ([ "_$TEST_SUITE" == "_unit" ] && [ "_${TRAVIS_JDK_VERSION}" == "_oraclejdk8" ]); then
@@ -50,6 +48,7 @@ else
 fi
 
 # Travis should only push from master ; not from pull requests
+# TODO: Introduce a "release"/"stable" branch
 if [ "_$TEST_SUITE" == "_unit" ] && [ "_$current_branch" == "_master" ]; then
   git_push
 else

--- a/scripts/deploy-source-code.sh
+++ b/scripts/deploy-source-code.sh
@@ -9,6 +9,7 @@ source "$BASEDIR"/scripts/logger.sh
 # fail on error
 set -e
 
+
 git_clone() {
   logi "Cloning https://github.com/jflex-de/jflex/tree/aggregated-java-sources"
   git clone --depth 1 --branch aggregated-java-sources https://github.com/jflex-de/jflex.git repo
@@ -23,26 +24,34 @@ update_source() {
   logi "Remove unrelated sources and compile"
   ./compile.sh
   git add --all
+  logi "Git status"
+  git status
   git commit -a -m "Update from $version"
   cd ..
 }
 
 git_push() {
   cd repo
-  logi "Git log"
-  git --no-pager log
-  git diff --name-only HEAD^1
   logi "Push to https://github.com/jflex-de/jflex/tree/aggregated-java-sources"
+  git log -1
   git push
   cd ..
 }
 
-if [ -z "$CI" ] || [ "_$TEST_SUITE" -eq "_unit" ]; then
+current_branch=$(git rev-parse --abbrev-ref HEAD)
+logi "CI=$CI TEST_SUITE=$TEST_SUITE JDK=$TRAVIS_JDK_VERSION branch=$current_branch"
+
+if [ -z "$CI" ] || \
+    ([ "_$TEST_SUITE" == "_unit" ] && [ "_${TRAVIS_JDK_VERSION}" == "_oraclejdk8" ]); then
   git_clone
   update_source
+else
+  logi "Skipping update in CI for test suite '$TEST_SUITE' (JDK='$TRAVIS_JDK_VERSION')"
 fi
 
 # Travis should only push from master ; not from pull requests
-if [ "_$TEST_SUITE" -eq "_unit" ] && [ "_$(git rev-parse --abbrev-ref HEAD)" -eq "_master" ]; then
+if [ "_$TEST_SUITE" == "_unit" ] && [ "_$current_branch" == "_master" ]; then
   git_push
+else
+  logi "Skipping git push in branch '$current_branch'"
 fi


### PR DESCRIPTION
* typo: s/desploy/deploy
  Somehow, Travis doesn't fail if a script doesn't exits...
* Also add logging in deploy-source-code.sh