### PR TITLE
Update maven-project-info-reports-plugin to version 3.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -316,9 +316,7 @@
     <plugins>
       <plugin>
         <artifactId>maven-project-info-reports-plugin</artifactId>
-        <!-- Use a version compatible with maven 3
-             https://maven.apache.org/plugins/maven-site-plugin/maven-3.html -->
-        <version>2.2</version>
+        <version>3.0.0</version>
         <reportSets>
           <reportSet>
             <reports>


### PR DESCRIPTION
Hopefully, this will fix Travis
```
[INFO] <<< maven-javadoc-plugin:2.10.1:test-javadoc < generate-test-sources @ jflex-maven-plugin <<<
...
[ERROR] Unable to determine if resource aopalliance:aopalliance:jar:1.0:compile exists in https://repository.apache.org/releases/
```