### PR TITLE
Deploy script must do git config to set Travis identity

### DIFF
--- a/scripts/deploy-source-code.sh
+++ b/scripts/deploy-source-code.sh
@@ -18,6 +18,8 @@ update_source() {
   version=$(ls target/jflex-*-sources.jar)
   logi "Updating sources from $version"
   cd repo
+  git config user.name "Travis CI"
+  git config user.email "deploy@travis-ci.org"
   git rm -r META-INF jflex java_cup UnicodeProperties.java.skeleton
   jar -xf ../target/jflex-*-sources.jar
   logi "Remove unrelated sources"


### PR DESCRIPTION
Fix:

[aggregated-java-sources 5915c76] Update from target/jflex-parent-1.7.0-sources.jar
 49 files changed, 305 insertions(+), 256 deletions(-)
Push to https://github.com/jflex-de/jflex/tree/aggregated-java-sources
commit 5915c766e5ff4352013bd1f618a337e2f006e6b3
Author: Travis CI User <travis@example.org>
Date:   Fri Sep 21 08:52:30 2018 +0000
    Update from target/jflex-parent-1.7.0-sources.jar
remote: Invalid username or password.
fatal: Authentication failed for 'https://github.com/jflex-de/jflex.git/'
Script failed with status 128