### PR TITLE
Use ssh to clone the repository

### DIFF
--- a/scripts/deploy-source-code.sh
+++ b/scripts/deploy-source-code.sh
@@ -11,7 +11,7 @@ set -e
 
 git_clone() {
   logi "Cloning https://github.com/jflex-de/jflex/tree/aggregated-java-sources"
-  git clone --depth 1 --branch aggregated-java-sources https://github.com/jflex-de/jflex.git repo
+  git clone --depth 1 --branch aggregated-java-sources git@github.com:jflex-de/jflex.git repo
 }
 
 update_source() {


### PR DESCRIPTION
The commit fails because Travis fails to authenticate over https.

commit 2badfd11fa1f8d9ca79ec12f21609e9ec3d00b1a
Author: Travis CI <deploy@travis-ci.org>
Date:   Fri Sep 21 10:11:55 2018 +0000
    Update from target/jflex-parent-1.7.0-sources.jar
remote: Invalid username or password.
fatal: Authentication failed for 'https://github.com/jflex-de/jflex.git/'
Script failed with status 128
failed to deploy