### PR TITLE
Use git clone on https with existing GITHUB_TOKEN

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ branches:
   only:
   - master
   - aggregated-java-sources
+  - travis
 
 language: java
 
@@ -59,7 +60,9 @@ deploy:
 - provider: script
   skip_cleanup: true
   on:
-    branch: master
+    branch:
+    - master
+    - travis
     condition:
     - $TEST_SUITE = unit
     - $TRAVIS_JDK_VERSION = oraclejdk8

--- a/scripts/deploy-source-code.sh
+++ b/scripts/deploy-source-code.sh
@@ -10,8 +10,13 @@ source "$BASEDIR"/scripts/logger.sh
 set -e
 
 git_clone() {
-  logi "Cloning https://[GITHUB_TOKEN]@github.com/jflex-de/jflex/tree/aggregated-java-sources"
-  git clone --depth 1 --branch aggregated-java-sources "https://${GITHUB_TOKEN}@github.com/jflex-de/jflex.git" repo > /dev/null 2>&1
+  if [[ -z "$CI" ]]; then
+    logi "Cloning ssh://git@github.com:jflex-de/jflex.git (aggregated-java-sources)"
+    git clone --depth 1 --branch aggregated-java-sources "git@github.com:jflex-de/jflex.git" repo > /dev/null 2>&1
+  else
+    logi "Cloning https://[GITHUB_TOKEN]@github.com/jflex-de/jflex/tree/aggregated-java-sources"
+    # SECURITY NOTICE: Be sure to send stdout & stderr to /dev/null so that the the ${GITHUB_TOKEN} is never revealed
+    git clone --depth 1 --branch aggregated-java-sources "https://${GITHUB_TOKEN}@github.com/jflex-de/jflex.git" repo > /dev/null 2>&1
 }
 
 update_source() {

--- a/scripts/deploy-source-code.sh
+++ b/scripts/deploy-source-code.sh
@@ -17,6 +17,7 @@ git_clone() {
     logi "Cloning https://[GITHUB_TOKEN]@github.com/jflex-de/jflex/tree/aggregated-java-sources"
     # SECURITY NOTICE: Be sure to send stdout & stderr to /dev/null so that the the ${GITHUB_TOKEN} is never revealed
     git clone --depth 1 --branch aggregated-java-sources "https://${GITHUB_TOKEN}@github.com/jflex-de/jflex.git" repo > /dev/null 2>&1
+  fi
 }
 
 update_source() {

--- a/scripts/deploy-source-code.sh
+++ b/scripts/deploy-source-code.sh
@@ -10,8 +10,8 @@ source "$BASEDIR"/scripts/logger.sh
 set -e
 
 git_clone() {
-  logi "Cloning https://github.com/jflex-de/jflex/tree/aggregated-java-sources"
-  git clone --depth 1 --branch aggregated-java-sources git@github.com:jflex-de/jflex.git repo
+  logi "Cloning https://[GITHUB_TOKEN]@github.com/jflex-de/jflex/tree/aggregated-java-sources"
+  git clone --depth 1 --branch aggregated-java-sources "https://${GITHUB_TOKEN}@github.com/jflex-de/jflex.git" repo > /dev/null 2>&1
 }
 
 update_source() {


### PR DESCRIPTION
The `deploy-source.sh` script doesn't work on Travis because

Push to https://github.com/jflex-de/jflex/tree/aggregated-java-sources
commit 03692fce9a2385a54ae3b95435811e057881056b
Author: Travis CI User travis@example.org
Date: Fri Sep 21 09:36:07 2018 +0000
Update from target/jflex-parent-1.7.0-sources.jar
remote: Invalid username or password.
fatal: Authentication failed for 'https://github.com/jflex-de/jflex.git/'
Script failed with status 128

