### PR TITLE
Temporarily Dont deploy aggregated-java-sources

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ branches:
   only:
   - master
   - aggregated-java-sources
+  - travis
 
 language: java
 
@@ -59,8 +60,10 @@ deploy:
 - provider: script
   skip_cleanup: true
   on:
-    branch: master
+    branch:
+    - master
+    - travis
     condition:
     - $TEST_SUITE = unit
     - $TRAVIS_JDK_VERSION = oraclejdk8
-  script: true || ./scripts/deploy-source-code.sh
+  script: ./scripts/deploy-source-code.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,4 +63,4 @@ deploy:
     condition:
     - $TEST_SUITE = unit
     - $TRAVIS_JDK_VERSION = oraclejdk8
-  script: ./scripts/deploy-source-code.sh
+  script: true || ./scripts/deploy-source-code.sh


### PR DESCRIPTION
This script doesn't work on Travis because

Push to https://github.com/jflex-de/jflex/tree/aggregated-java-sources
commit 03692fce9a2385a54ae3b95435811e057881056b
Author: Travis CI User travis@example.org
Date: Fri Sep 21 09:36:07 2018 +0000
Update from target/jflex-parent-1.7.0-sources.jar
remote: Invalid username or password.
fatal: Authentication failed for 'https://github.com/jflex-de/jflex.git/'
Script failed with status 128