### PR TITLE
Don't commit on a clean working tree for aggregated-java-sources

### DIFF
--- a/scripts/deploy-source-code.sh
+++ b/scripts/deploy-source-code.sh
@@ -34,7 +34,9 @@ update_source() {
   git add --all
   logi "Git status"
   git status
-  git commit -a -m "Update from $version"
+  # Don't commit if the diff is empty.
+  # git commit fails if the commit is empty, which makes Travis build fail.
+  git diff-index --quiet HEAD || git commit -a -m "Update from $version"
   cd ..
 }
 
@@ -56,8 +58,7 @@ if [[ -z "$CI" ]]; then
   logi "Check the last commit"
   logi "git log -1"
   logi "git diff HEAD^1"
-  logi "And run:"
-  logi "git push"
+  logi "# git push"
 else
   git_push
 fi


### PR DESCRIPTION
Travis fails with 

```
Git status
On branch aggregated-java-sources
Your branch is up to date with 'origin/aggregated-java-sources'.
nothing to commit, working tree clean
On branch aggregated-java-sources
Your branch is up to date with 'origin/aggregated-java-sources'.
nothing to commit, working tree clean
Script failed with status 1
failed to deploy
```