### PR TITLE
git:ignore bazel-*

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Build artefacts
 **/target
 dependency-reduced-pom.xml
+bazel-*
 
 # IntelliJ
 *.iml


### PR DESCRIPTION
I have an experimental branch to build with bazel. https://github.com/regisd/jflex/tree/bazel
Ignore these build directories.