### PR TITLE
jflex.bat: JFLEX vars definable in cmd shell

### DIFF
--- a/jflex/bin/jflex.bat
+++ b/jflex/bin/jflex.bat
@@ -1,8 +1,8 @@
 @echo off
-REM Please adjust JFLEX_HOME to suit your needs
+REM Please adjust JFLEX_HOME and JFLEX_VERSION to suit your needs
 REM (please do not add a trailing backslash)
 
-set JFLEX_HOME=C:\JFLEX
-set JFLEX_VERSION=1.7.1-SNAPSHOT
+if not defined JFLEX_HOME set JFLEX_HOME=C:\JFLEX
+if not defined JFLEX_VERSION set JFLEX_VERSION=1.7.1-SNAPSHOT
 
-java -Xmx128m -jar "%JFLEX_HOME%"\lib\jflex-full-%JFLEX_VERSION%.jar %*
+java -Xmx128m -jar "%JFLEX_HOME%\lib\jflex-full-%JFLEX_VERSION%.jar" %*


### PR DESCRIPTION
Allow to define `JFLEX_HOME` and `JFLEX_VERSION` as environment variables.
Also, plus quote path to jar file.