### PR TITLE
expl zeroreader: diff ignoring different EOL

### DIFF
--- a/jflex/examples/zero-reader/Makefile
+++ b/jflex/examples/zero-reader/Makefile
@@ -10,7 +10,7 @@ LEXER      = ZeroLexer
 all: test
 
 test: output.txt
-	@(diff output.txt lexer-output.good && echo "Test OK!") || echo "Test failed!"
+	@(diff --strip-trailing-cr output.txt lexer-output.good && echo "Test OK!") || echo "Test failed!"
 
 output.txt: $(LEXER).class test-input.txt
 	$(JAVA) $(LEXER) test-input.txt > output.txt


### PR DESCRIPTION
`diff` should ignore different EOL when diffing the expected result (LF) against the produced result with potentially different EOL (e.g. CRLF on Windows).