### PR TITLE
Fix git commit --message for aggregate-java-sources

### DIFF
--- a/scripts/deploy-source-code.sh
+++ b/scripts/deploy-source-code.sh
@@ -45,7 +45,10 @@ update_source() {
   git status
   # Don't commit if the diff is empty.
   # git commit fails if the commit is empty, which makes Travis build fail.
-  git diff-index --quiet HEAD || git commit -a -m "Update from $version\n\nInitial $gitlog"
+  git diff-index --quiet HEAD || \
+      git commit -a \
+          -m "Update from $version" \
+          -m "Initial $gitlog"
   cd ..
 }
 


### PR DESCRIPTION
In #361, the initial commit message was added in the commit of the aggregate-java-sources.
Unfortunately `\n` is copied verbatim.

Use multiple `--message` args instead.

From the doc:
> -m <msg>
> --message=<msg>
> Use the given <msg> as the commit message. If multiple -m options are given, their values are concatenated as separate paragraphs.