### PR TITLE
Travis: drastically reduce the build matrix.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,16 +18,16 @@ matrix:
   include:
   - name: "Java format"
     script: scripts/test-java-format.sh
-  - name: "Ant JDK8"
-    script: scripts/run-ant.sh
-    sdk: oraclejdk8
-  - name: "Ant JDK9"
-    script: scripts/run-ant.sh
   - name: "Maven unit tests"
     script: scripts/test-unit.sh
     env: TEST_SUITE=unit
   - name: "Regression tests"
     script: scripts/test-regression.sh
+  - name: "Ant JDK8"
+    script: scripts/run-ant.sh
+    sdk: oraclejdk8
+  - name: "Ant JDK9"
+    script: scripts/run-ant.sh
 
 # Empty the previously built artifacts
 # They cannot be deleted in the before_cache phase,

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,13 @@ jdk:
 
 matrix:
   include:
-  - name: "Java format"
+  - name: "Check Java format"
     script: scripts/test-java-format.sh
-  - name: "Maven unit tests"
-    script: scripts/test-unit.sh
+  - name: "Maven everything"
+    script:
+    - scripts/test-unit.sh
+    - scripts/mvn-site.sh
+    - scripts/mvn-aggregate-srcs.sh
     env: TEST_SUITE=unit
   - name: "Regression tests"
     script: scripts/test-regression.sh
@@ -34,13 +37,12 @@ matrix:
 # otherwise `mvn site` fails in the before_deploy phase.
 before_install: ./scripts/clean.sh
 
-install: ./mvnw -version
+install:
+- java -version
+- javac -version
+- ./mvnw -version
 
-script: ./scripts/run-tests.sh
-
-after_success:
-- test $TEST_SUITE="unit" && ./scripts/mvn-site.sh
-- test $TEST_SUITE="unit" && ./scripts/mvn-aggregate-srcs.sh
+script: scripts/run-tests.sh
 
 # Travis sometimes fails to download deps from repo1.maven.org
 # A cache avoids downloading too much, and will also speed up the build.

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,9 @@ git:
 
 language: java
 
-jdk: openjdk9
+jdk:
+- oraclejdk8
+- openjdk9
 
 matrix:
   include:
@@ -26,7 +28,7 @@ matrix:
     TEST_SUITE=unit
   - name: "Regression tests"
     TEST_SUITE=regression
-       
+
 # Empty the previously built artifacts
 # They cannot be deleted in the before_cache phase,
 # otherwise `mvn site` fails in the before_deploy phase.

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,22 +12,23 @@ git:
 language: java
 
 jdk:
-- oraclejdk8
 - openjdk9
 
 matrix:
   include:
   - name: "Java format"
-    TEST_SUITE=java-format
+    env: TEST_SUITE=java-format
   - name: "Ant JDK8"
     sdk: oraclejdk8
-    TEST_SUITE=ant
+    env: TEST_SUITE=ant
   - name: "Ant JDK9"
-    TEST_SUITE=ant
+    env: TEST_SUITE=ant
   - name: "Maven unit tests"
-    TEST_SUITE=unit
+    env: TEST_SUITE=unit
   - name: "Regression tests"
-    TEST_SUITE=regression
+    env: TEST_SUITE=regression
+  - name: "Do nothing"
+    script: true
 
 # Empty the previously built artifacts
 # They cannot be deleted in the before_cache phase,

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,18 +11,22 @@ git:
 
 language: java
 
-# TODO(regisd) Remove the build matrix ; it really makes the deploy phase more complex
-jdk:
-- oraclejdk8
-- openjdk9
+jdk: openjdk9
 
-env:
-  matrix:
-  - TEST_SUITE=java-format
-  - TEST_SUITE=ant
-  - TEST_SUITE=unit
-  - TEST_SUITE=regression
-
+matrix:
+  include:
+  - name: "Java format"
+    TEST_SUITE=java-format
+  - name: "Ant JDK8"
+    sdk: oraclejdk8
+    TEST_SUITE=ant
+  - name: "Ant JDK9"
+    TEST_SUITE=ant
+  - name: "Maven unit tests"
+    TEST_SUITE=unit
+  - name: "Regression tests"
+    TEST_SUITE=regression
+       
 # Empty the previously built artifacts
 # They cannot be deleted in the before_cache phase,
 # otherwise `mvn site` fails in the before_deploy phase.

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,21 +11,23 @@ git:
 
 language: java
 
-jdk: openjdk9
+jdk:
+- openjdk9
 
 matrix:
   include:
   - name: "Java format"
-    env: TEST_SUITE=java-format
+    script: scripts/test-java-format.sh
   - name: "Ant JDK8"
+    script: scripts/run-ant.sh
     sdk: oraclejdk8
-    env: TEST_SUITE=ant
   - name: "Ant JDK9"
-    env: TEST_SUITE=ant
+    script: scripts/run-ant.sh
   - name: "Maven unit tests"
+    script: scripts/test-unit.sh
     env: TEST_SUITE=unit
   - name: "Regression tests"
-    env: TEST_SUITE=regression
+    script: scripts/test-regression.sh
 
 # Empty the previously built artifacts
 # They cannot be deleted in the before_cache phase,
@@ -37,8 +39,8 @@ install: ./mvnw -version
 script: ./scripts/run-tests.sh
 
 after_success:
-- test $TEST_SUITE = "unit" && ./scripts/mvn-site.sh
-- test $TEST_SUITE = "unit" && ./scripts/mvn-aggregate-srcs.sh
+- test $TEST_SUITE="unit" && ./scripts/mvn-site.sh
+- test $TEST_SUITE="unit" && ./scripts/mvn-aggregate-srcs.sh
 
 # Travis sometimes fails to download deps from repo1.maven.org
 # A cache avoids downloading too much, and will also speed up the build.
@@ -59,7 +61,7 @@ deploy:
     branch: release
     condition:
     - $TEST_SUITE = unit
-    - $TRAVIS_JDK_VERSION = oraclejdk8
+    - $TRAVIS_JDK_VERSION = openjdk9
   local_dir: target/maven-staging-site/maven-site
   # GITHUB_TOKEN set in travis-ci.org dashboard
   github_token: $GITHUB_TOKEN
@@ -75,5 +77,5 @@ deploy:
     - travis
     condition:
     - $TEST_SUITE = unit
-    - $TRAVIS_JDK_VERSION = oraclejdk8
+    - $TRAVIS_JDK_VERSION = openjdk9
   script: ./scripts/deploy-source-code.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,7 @@ git:
 
 language: java
 
-jdk:
-- openjdk9
+jdk: openjdk9
 
 matrix:
   include:
@@ -27,8 +26,6 @@ matrix:
     env: TEST_SUITE=unit
   - name: "Regression tests"
     env: TEST_SUITE=regression
-  - name: "Do nothing"
-    script: true
 
 # Empty the previously built artifacts
 # They cannot be deleted in the before_cache phase,

--- a/scripts/run-ant.sh
+++ b/scripts/run-ant.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+CWD="$PWD"
+BASEDIR="$(cd "$(dirname "$0")" && pwd -P)"/..
+# Provides the logi function
+source "$BASEDIR"/scripts/logger.sh
+# Maven executable
+MVN="$BASEDIR"/mvnw
+# fail on error
+set -e
+
+if [[ -z "$TEST_SUITE" || "$TEST_SUITE" == "ant" ]]; then
+  "$BASEDIR"/scripts/ant-build.sh
+  "$BASEDIR"/scripts/test-examples.sh
+fi
+
+logi "Success"
+cd "$CWD"

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -9,15 +9,13 @@ MVN="$BASEDIR"/mvnw
 # fail on error
 set -e
 
-echo '==============================  JAVA VERSION  =============================='
-java -version
-javac -version
-echo '============================================================================'
+if [[ $TRAVIS ]]; then
+  loge "This script is only for manual invocation"
+  exit 1
+fi
 
 # Clean environment
-if [[ ! $TRAVIS ]]; then
-  "$BASEDIR"/scripts/clean.sh
-fi
+"$BASEDIR"/scripts/clean.sh
 
 # Travis then runs _in parallel_ (but we do it in sequence)
 if [[ -z "$TEST_SUITE" || "$TEST_SUITE" == "java-format" ]]; then


### PR DESCRIPTION
We have useless matrix expansion (e.g. java-format un JDK8 and java-format in JDK9).

Instead of expanding all possible values, explicitely define the inclusion we want.