### PR TITLE
Minor: fix shutdown condition in scritpts/bazel.sh

### DIFF
--- a/scripts/bazel.sh
+++ b/scripts/bazel.sh
@@ -27,12 +27,12 @@ logi "Test everything"
 logi "==============="
 $BAZEL test //...
 
-if [[ -z"$CI" ]]; then
-  logi "Done"
-else
+if [[ "$CI" ]]; then
   logi "Shutdown"
   logi "========"
   $BAZEL shutdown
+else
+  logi "Done"
 fi
 
 cd "$CWD"


### PR DESCRIPTION
Wrong syntax
```
if [[ -z"$CI" ]]
```
 is always true