### PR TITLE
Use SNAPSHOT in jflex() Skylark rule

### DIFF
--- a/jflex/examples/WORKSPACE
+++ b/jflex/examples/WORKSPACE
@@ -16,4 +16,5 @@ maven_jar(
 )
 
 load("//third_party:generate_workspace.bzl", "generated_maven_jars")
+
 generated_maven_jars()

--- a/jflex/examples/third_party/de/jflex/.gitignore
+++ b/jflex/examples/third_party/de/jflex/.gitignore
@@ -1,0 +1,7 @@
+# Maven is our main build system.
+# Maven builds jflex and cup_runtime
+# The artifacts should then be copied in this directory.
+# Run ./scripts/bazel.sh to do this automatically
+
+cup_runtime.jar
+jflex.jar

--- a/jflex/examples/third_party/de/jflex/BUILD
+++ b/jflex/examples/third_party/de/jflex/BUILD
@@ -11,9 +11,30 @@ java_binary(
 # Alias to latest version
 alias(
     name = "jflex",
-    actual = ":jflex_1_6_1",
+    actual = ":jflex_SNAPSHOT",
 )
 
+alias(
+    name = "cup_runtime",
+    actual = ":cup_runtime_SNAPSHOT",
+)
+
+# The snapshot is
+# - buitl by Maven
+# - copied in this directort by bazel.sh
+# It is not necessarily
+java_import(
+    name = "jflex_SNAPSHOT",
+    jars = ["jflex.jar"],
+    deps = [":cup_runtime"],
+)
+
+java_import(
+    name = "cup_runtime_SNAPSHOT",
+    jars = ["cup_runtime.jar"],
+)
+
+# TODO(#390) Replace old version by jflex-1.7.0 when all deps have been published on central repo.
 java_library(
     name = "jflex_1_6_1",
     # Only the latest version should be used

--- a/jflex/examples/third_party/de/jflex/build_rules.bzl
+++ b/jflex/examples/third_party/de/jflex/build_rules.bzl
@@ -3,20 +3,22 @@
 def _jflex_impl(ctx):
     """ Generates a Java lexer from a lex definition, using JFlex. """
 
-    # Output directory is bazel-genfiles, regardless of Java package defined in
+    # Output directory is bazel-genfiles/package, regardless of Java package defined in
     # the grammar
     output_dir = "/".join(
         [ctx.configuration.genfiles_dir.path, ctx.label.package],
     )
+
     # TODO(regisd): Add support for JFlex options.
-    maybe_skel =  [ctx.file.skeleton] if ctx.file.skeleton else []
+    maybe_skel = [ctx.file.skeleton] if ctx.file.skeleton else []
     cmd_maybe_skel = ["-skel", ctx.file.skeleton.path] if ctx.file.skeleton else []
     arguments = (
-        cmd_maybe_skel + \
+        cmd_maybe_skel +
         # Option to specify output directory
-        ["-d", output_dir] + \
+        ["-d", output_dir] +
         # Input files
-        [f.path for f in ctx.files.srcs])
+        [f.path for f in ctx.files.srcs]
+    )
     ctx.action(
         inputs = ctx.files.srcs + maybe_skel,
         outputs = ctx.outputs.outputs,
@@ -33,7 +35,7 @@ jflex = rule(
             allow_empty = False,
             allow_files = True,
             mandatory = True,
-            doc = "a list of grammar specifications"
+            doc = "a list of grammar specifications",
         ),
         "skeleton": attr.label(
             allow_files = True,

--- a/scripts/bazel.sh
+++ b/scripts/bazel.sh
@@ -14,6 +14,14 @@ else
   BAZEL='bazel'
 fi
 
+# This will allow to import the jflex jar
+"$BASEDIR"/scripts/mvn-install-fastbuild.sh
+logi "Copy JFlex jar in //third_party"
+logi "==============================="
+# NB This will fail if there are multiple versions of the jflex jar.
+cp "$BASEDIR"/jflex/target/jflex-1.*.jar  "$BASEDIR"/jflex/examples/third_party/de/jflex/jflex.jar
+cp "$BASEDIR"/cup/cup_runtime/target/cup_runtime-*.jar  "$BASEDIR"/jflex/examples/third_party/de/jflex/cup_runtime.jar
+
 logi "Start Bazel"
 logi "==========="
 cd "$BASEDIR"/jflex/examples

--- a/scripts/mvn-install-fastbuild.sh
+++ b/scripts/mvn-install-fastbuild.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+BASEDIR="$(cd "$(dirname "$0")" && pwd -P)"/..
+# Provides the logi function
+source "$BASEDIR"/scripts/logger.sh
+MVN="$BASEDIR"/mvnw
+
+QUIET=""
+if [[ "$TRAVIS" ]]; then
+  # Quiet mode shows errors only.
+  QUIET="--quiet"
+fi
+
+# TODO(regisd) Deifne the list of packages via the profile
+logi "Build and install JFlex only (-P fastbuild)"
+"$MVN" ${QUIET} -pl cup/cup,cup/cup_runtime,cup-maven-plugin,.,jflex -Pfastbuild install

--- a/scripts/test-examples.sh
+++ b/scripts/test-examples.sh
@@ -10,16 +10,9 @@ MVN="$BASEDIR"/mvnw
 # Exit with error in case of error (see #242)
 set -e
 
-logi "Compile, test and install all"
+logi "Compile, test and install all "
 logi "============================="
-# NB: Installs jflex in local repo
-# implies: validate, compile, test, package, verify, install
-if [[ "$TRAVIS" ]]; then
-  # Quiet mode shows errors only.
-  "$MVN" -Pfastbuild install --quiet
-else
-  "$MVN" -Pfastbuild install
-fi
+"$BASEDIR"/scripts/mvn-install-fastbuild.sh
 
 logi "Run jflex examples with ant"
 logi "==========================="

--- a/scripts/test-regression.sh
+++ b/scripts/test-regression.sh
@@ -10,10 +10,10 @@ MVN="$BASEDIR"/mvnw
 # fail on error
 set -e
 
-if [[ $TRAVIS ]]; then
-  logi "Compile and install all (no tests)"
-  # Travis has "`install: true` and hence jflex needs to be install in local repo
-  "$MVN" install -Pfastbuild --quiet
+if [[ $CI ]]; then
+  "$BASEDIR"/scripts/mvn-install-fastbuild.sh
+  # TODO(regisd) Why do we need cup? Isn't cup_runtime sufficient?
+  "$MVN" -Pfastbuild -pl cup,jflex-maven-plugin,testsuite/jflex-testsuite-maven-plugin install
 else
   # On local dev, ./run-tests has already installed all, so we can skip installation
   echo
@@ -21,6 +21,7 @@ fi
 
 
 logi "Run regression test cases"
+logi "========================="
 # regression test suite must run in its own directory
 cd "$BASEDIR"/testsuite/testcases; "$MVN" test
 cd "$CWD"


### PR DESCRIPTION
In bazel.sh:
1.  build jflex.jar and cup_runtime.jar
2.  copy these artifacts in examples/third_party/de/jflex
3.  BUILD can now java_import
4.  enjoy

Also, add a mvn-fastbuild.sh script that test-regressions.sh can also use.