### PR TITLE
Fix PMD violations

### DIFF
--- a/cup-maven-plugin/src/main/java/de/jflex/plugin/cup/GenerateMojo.java
+++ b/cup-maven-plugin/src/main/java/de/jflex/plugin/cup/GenerateMojo.java
@@ -149,12 +149,13 @@ public class GenerateMojo extends AbstractMojo {
   }
 
   private String findJavaPackage(File cupFile) throws IOException {
-    BufferedReader br = new BufferedReader(new FileReader(cupFile));
-    while (br.ready()) {
-      String line = br.readLine();
-      Optional<String> optJavaPackage = optionalJavaPackage(line);
-      if (optJavaPackage.isPresent()) {
-        return optJavaPackage.get();
+    try (BufferedReader br = new BufferedReader(new FileReader(cupFile))) {
+      while (br.ready()) {
+        String line = br.readLine();
+        Optional<String> optJavaPackage = optionalJavaPackage(line);
+        if (optJavaPackage.isPresent()) {
+          return optJavaPackage.get();
+        }
       }
     }
     return DEFAULT_JAVA_PACKAGE;

--- a/jflex-unicode-maven-plugin/src/main/java/jflex/DataFileType.java
+++ b/jflex-unicode-maven-plugin/src/main/java/jflex/DataFileType.java
@@ -86,11 +86,12 @@ public enum DataFileType {
   // SCRIPT_EXTENSIONS must follow SCRIPTS
   SCRIPT_EXTENSIONS("ScriptExtensions") {
     public void scan(URL url, UnicodeVersion version) throws IOException {
-      try (Reader reader = new InputStreamReader(url.openStream(), "UTF-8")){
-      ScriptExtensionsScanner scanner =
-          new ScriptExtensionsScanner(reader, version, "Script_Extensions");
-      scanner.scan();
-    }}
+      try (Reader reader = new InputStreamReader(url.openStream(), "UTF-8")) {
+        ScriptExtensionsScanner scanner =
+            new ScriptExtensionsScanner(reader, version, "Script_Extensions");
+        scanner.scan();
+      }
+    }
   },
 
   BLOCKS("Blocks") {

--- a/jflex-unicode-maven-plugin/src/main/java/jflex/DataFileType.java
+++ b/jflex-unicode-maven-plugin/src/main/java/jflex/DataFileType.java
@@ -11,50 +11,55 @@ import java.util.regex.Pattern;
 public enum DataFileType {
   PROPERTY_ALIASES("PropertyAliases") {
     public void scan(URL url, UnicodeVersion version) throws IOException {
-      Reader reader = new InputStreamReader(url.openStream(), "UTF-8");
-      PropertyAliasesScanner scanner = new PropertyAliasesScanner(reader, version);
-      scanner.scan();
+      try (Reader reader = new InputStreamReader(url.openStream(), "UTF-8")) {
+        PropertyAliasesScanner scanner = new PropertyAliasesScanner(reader, version);
+        scanner.scan();
+      }
     }
   },
 
   PROPERTY_VALUE_ALIASES("PropertyValueAliases") {
     public void scan(URL url, UnicodeVersion version) throws IOException {
-      Reader reader = new InputStreamReader(url.openStream(), "UTF-8");
-      PropertyValueAliasesScanner scanner = new PropertyValueAliasesScanner(reader, version);
-      scanner.scan();
+      try (Reader reader = new InputStreamReader(url.openStream(), "UTF-8")) {
+        PropertyValueAliasesScanner scanner = new PropertyValueAliasesScanner(reader, version);
+        scanner.scan();
+      }
     }
   },
 
   UNICODE_DATA("UnicodeData") {
     public void scan(URL url, UnicodeVersion version) throws IOException {
-      Reader reader = new InputStreamReader(url.openStream(), "UTF-8");
-      UnicodeDataScanner scanner = new UnicodeDataScanner(reader, version);
-      scanner.scan();
+      try (Reader reader = new InputStreamReader(url.openStream(), "UTF-8")) {
+        UnicodeDataScanner scanner = new UnicodeDataScanner(reader, version);
+        scanner.scan();
+      }
     }
   },
 
   PROPLIST("PropList") {
     public void scan(URL url, UnicodeVersion version) throws IOException {
-      Reader reader = new InputStreamReader(url.openStream(), "UTF-8");
-      // Before Unicode 3.1, PropList-X.X.X.txt used a different format.
-      // Before Unicode 2.0, PropList-X.X.X.txt did not exist.
-      if (version.majorMinorVersion.equals("2.0")
-          || version.majorMinorVersion.equals("2.1")
-          || version.majorMinorVersion.equals("3.0")) {
-        ArchaicPropListScanner scanner = new ArchaicPropListScanner(reader, version);
-        scanner.scan();
-      } else {
-        BinaryPropertiesFileScanner scanner = new BinaryPropertiesFileScanner(reader, version);
-        scanner.scan();
+      try (Reader reader = new InputStreamReader(url.openStream(), "UTF-8")) {
+        // Before Unicode 3.1, PropList-X.X.X.txt used a different format.
+        // Before Unicode 2.0, PropList-X.X.X.txt did not exist.
+        if (version.majorMinorVersion.equals("2.0")
+            || version.majorMinorVersion.equals("2.1")
+            || version.majorMinorVersion.equals("3.0")) {
+          ArchaicPropListScanner scanner = new ArchaicPropListScanner(reader, version);
+          scanner.scan();
+        } else {
+          BinaryPropertiesFileScanner scanner = new BinaryPropertiesFileScanner(reader, version);
+          scanner.scan();
+        }
       }
     }
   },
 
   DERIVED_CORE_PROPERTIES("DerivedCoreProperties") {
     public void scan(URL url, UnicodeVersion version) throws IOException {
-      Reader reader = new InputStreamReader(url.openStream(), "UTF-8");
-      BinaryPropertiesFileScanner scanner = new BinaryPropertiesFileScanner(reader, version);
-      scanner.scan();
+      try (Reader reader = new InputStreamReader(url.openStream(), "UTF-8")) {
+        BinaryPropertiesFileScanner scanner = new BinaryPropertiesFileScanner(reader, version);
+        scanner.scan();
+      }
     }
   },
 
@@ -70,89 +75,96 @@ public enum DataFileType {
           || version.majorMinorVersion.equals("4.1")) {
         defaultPropertyValue = "Common";
       }
-      Reader reader = new InputStreamReader(url.openStream(), "UTF-8");
-      EnumeratedPropertyFileScanner scanner =
-          new EnumeratedPropertyFileScanner(reader, version, "Script", defaultPropertyValue);
-      scanner.scan();
+      try (Reader reader = new InputStreamReader(url.openStream(), "UTF-8")) {
+        EnumeratedPropertyFileScanner scanner =
+            new EnumeratedPropertyFileScanner(reader, version, "Script", defaultPropertyValue);
+        scanner.scan();
+      }
     }
   },
 
   // SCRIPT_EXTENSIONS must follow SCRIPTS
   SCRIPT_EXTENSIONS("ScriptExtensions") {
     public void scan(URL url, UnicodeVersion version) throws IOException {
-      Reader reader = new InputStreamReader(url.openStream(), "UTF-8");
+      try (Reader reader = new InputStreamReader(url.openStream(), "UTF-8")){
       ScriptExtensionsScanner scanner =
           new ScriptExtensionsScanner(reader, version, "Script_Extensions");
       scanner.scan();
-    }
+    }}
   },
 
   BLOCKS("Blocks") {
     public void scan(URL url, UnicodeVersion version) throws IOException {
-      Reader reader = new InputStreamReader(url.openStream(), "UTF-8");
-      // Before Unicode 3.1, Blocks-X.txt used a different format.
-      // Before Unicode 2.0, Blocks-X.txt did not exist.
-      if (version.majorMinorVersion.equals("2.0")
-          || version.majorMinorVersion.equals("2.1")
-          || version.majorMinorVersion.equals("3.0")) {
-        ArchaicBlocksScanner scanner = new ArchaicBlocksScanner(reader, version);
-        scanner.scan();
-      } else {
-        EnumeratedPropertyFileScanner scanner =
-            new EnumeratedPropertyFileScanner(reader, version, "Block", "No_Block");
-        scanner.scan();
+      try (Reader reader = new InputStreamReader(url.openStream(), "UTF-8")) {
+        // Before Unicode 3.1, Blocks-X.txt used a different format.
+        // Before Unicode 2.0, Blocks-X.txt did not exist.
+        if (version.majorMinorVersion.equals("2.0")
+            || version.majorMinorVersion.equals("2.1")
+            || version.majorMinorVersion.equals("3.0")) {
+          ArchaicBlocksScanner scanner = new ArchaicBlocksScanner(reader, version);
+          scanner.scan();
+        } else {
+          EnumeratedPropertyFileScanner scanner =
+              new EnumeratedPropertyFileScanner(reader, version, "Block", "No_Block");
+          scanner.scan();
+        }
       }
     }
   },
 
   LINE_BREAK("LineBreak") {
     public void scan(URL url, UnicodeVersion version) throws IOException {
-      Reader reader = new InputStreamReader(url.openStream(), "UTF-8");
-      // In Unicode 3.0, LineBreak-X.txt used a different format.
-      // Before Unicode 3.0, LineBreak-X.txt did not exist.
-      if (version.majorMinorVersion.equals("3.0")) {
-        ArchaicLineBreakScanner scanner = new ArchaicLineBreakScanner(reader, version);
-        scanner.scan();
-      } else {
-        EnumeratedPropertyFileScanner scanner =
-            new EnumeratedPropertyFileScanner(reader, version, "Line_Break", "XX");
-        scanner.scan();
+      try (Reader reader = new InputStreamReader(url.openStream(), "UTF-8")) {
+        // In Unicode 3.0, LineBreak-X.txt used a different format.
+        // Before Unicode 3.0, LineBreak-X.txt did not exist.
+        if (version.majorMinorVersion.equals("3.0")) {
+          ArchaicLineBreakScanner scanner = new ArchaicLineBreakScanner(reader, version);
+          scanner.scan();
+        } else {
+          EnumeratedPropertyFileScanner scanner =
+              new EnumeratedPropertyFileScanner(reader, version, "Line_Break", "XX");
+          scanner.scan();
+        }
       }
     }
   },
 
   GRAPHEME_BREAK_PROPERTY("GraphemeBreakProperty") {
     public void scan(URL url, UnicodeVersion version) throws IOException {
-      Reader reader = new InputStreamReader(url.openStream(), "UTF-8");
-      EnumeratedPropertyFileScanner scanner =
-          new EnumeratedPropertyFileScanner(reader, version, "Grapheme_Cluster_Break", "Other");
-      scanner.scan();
+      try (Reader reader = new InputStreamReader(url.openStream(), "UTF-8")) {
+        EnumeratedPropertyFileScanner scanner =
+            new EnumeratedPropertyFileScanner(reader, version, "Grapheme_Cluster_Break", "Other");
+        scanner.scan();
+      }
     }
   },
 
   SENTENCE_BREAK_PROPERTY("SentenceBreakProperty") {
     public void scan(URL url, UnicodeVersion version) throws IOException {
-      Reader reader = new InputStreamReader(url.openStream(), "UTF-8");
-      EnumeratedPropertyFileScanner scanner =
-          new EnumeratedPropertyFileScanner(reader, version, "Sentence_Break", "Other");
-      scanner.scan();
+      try (Reader reader = new InputStreamReader(url.openStream(), "UTF-8")) {
+        EnumeratedPropertyFileScanner scanner =
+            new EnumeratedPropertyFileScanner(reader, version, "Sentence_Break", "Other");
+        scanner.scan();
+      }
     }
   },
 
   WORD_BREAK_PROPERTY("WordBreakProperty") {
     public void scan(URL url, UnicodeVersion version) throws IOException {
-      Reader reader = new InputStreamReader(url.openStream(), "UTF-8");
-      EnumeratedPropertyFileScanner scanner =
-          new EnumeratedPropertyFileScanner(reader, version, "Word_Break", "Other");
-      scanner.scan();
+      try (Reader reader = new InputStreamReader(url.openStream(), "UTF-8")) {
+        EnumeratedPropertyFileScanner scanner =
+            new EnumeratedPropertyFileScanner(reader, version, "Word_Break", "Other");
+        scanner.scan();
+      }
     }
   },
 
   DERIVED_AGE("DerivedAge") {
     public void scan(URL url, UnicodeVersion version) throws IOException {
-      Reader reader = new InputStreamReader(url.openStream(), "UTF-8");
-      DerivedAgeScanner scanner = new DerivedAgeScanner(reader, version);
-      scanner.scan();
+      try (Reader reader = new InputStreamReader(url.openStream(), "UTF-8")) {
+        DerivedAgeScanner scanner = new DerivedAgeScanner(reader, version);
+        scanner.scan();
+      }
     }
     /**
      * Always return the URL for the latest Unicode version's DerivedAge.txt, except for Unicode

--- a/jflex/src/main/java/jflex/IntCharSet.java
+++ b/jflex/src/main/java/jflex/IntCharSet.java
@@ -223,7 +223,7 @@ public final class IntCharSet {
   @Override
   public int hashCode() {
     int h = 1;
-    for (Interval interval :intervals) {
+    for (Interval interval : intervals) {
       h *= 1000003;
       h ^= interval.hashCode();
     }

--- a/jflex/src/main/java/jflex/IntCharSet.java
+++ b/jflex/src/main/java/jflex/IntCharSet.java
@@ -117,7 +117,7 @@ public final class IntCharSet {
       if (elem.contains(interval)) return;
 
       if (elem.start > interval.end + 1) {
-        intervals.add(i, Interval.copyOf(interval));
+        intervals.add(i, new Interval(interval));
         return;
       }
 
@@ -142,7 +142,7 @@ public final class IntCharSet {
       return;
     }
 
-    intervals.add(Interval.copyOf(interval));
+    intervals.add(new Interval(interval));
   }
 
   /**

--- a/jflex/src/main/java/jflex/IntCharSet.java
+++ b/jflex/src/main/java/jflex/IntCharSet.java
@@ -14,25 +14,20 @@ import java.util.List;
 import jflex.unicode.UnicodeProperties;
 
 /**
- * CharSet implemented with intervals
- *
- * <p>[fixme: optimizations possible]
+ * CharSet implemented with intervals.
  *
  * @author Gerwin Klein
+ * @author Régis Décamps
  * @version JFlex 1.7.1-SNAPSHOT
  */
+// FIXME: optimizations possible
 public final class IntCharSet {
 
   private static final boolean DEBUG = false;
 
   /* invariant: all intervals are disjoint, ordered */
-  private List<Interval> intervals;
+  private List<Interval> intervals = new ArrayList<>();
   private int pos;
-
-  /** Constructor for IntCharSet. */
-  public IntCharSet() {
-    this.intervals = new ArrayList<>();
-  }
 
   /**
    * Constructor for IntCharSet.
@@ -49,7 +44,6 @@ public final class IntCharSet {
    * @param interval a {@link jflex.Interval} object.
    */
   public IntCharSet(Interval interval) {
-    this();
     intervals.add(interval);
   }
 
@@ -216,10 +210,24 @@ public final class IntCharSet {
    *
    * <p>o instanceof Interval
    */
+  @Override
   public boolean equals(Object o) {
+    if (!(o instanceof IntCharSet)) {
+      return false;
+    }
     IntCharSet set = (IntCharSet) o;
 
     return intervals.equals(set.intervals);
+  }
+
+  @Override
+  public int hashCode() {
+    int h = 1;
+    for (Interval interval :intervals) {
+      h *= 1000003;
+      h ^= interval.hashCode();
+    }
+    return h;
   }
 
   private int min(int a, int b) {

--- a/jflex/src/main/java/jflex/IntCharSet.java
+++ b/jflex/src/main/java/jflex/IntCharSet.java
@@ -29,20 +29,15 @@ public final class IntCharSet {
   private List<Interval> intervals = new ArrayList<>();
   private int pos;
 
-  /**
-   * Constructor for IntCharSet.
-   *
-   * @param c a int.
-   */
+  /** Creates an empty char set. */
+  public IntCharSet() {}
+
+  /** Creates a char set that contains only the given character. */
   public IntCharSet(int c) {
     this(new Interval(c, c));
   }
 
-  /**
-   * Constructor for IntCharSet.
-   *
-   * @param interval a {@link jflex.Interval} object.
-   */
+  /** Creates a charset that contains only one interval. */
   public IntCharSet(Interval interval) {
     intervals.add(interval);
   }
@@ -122,7 +117,7 @@ public final class IntCharSet {
       if (elem.contains(interval)) return;
 
       if (elem.start > interval.end + 1) {
-        intervals.add(i, new Interval(interval));
+        intervals.add(i, Interval.copyOf(interval));
         return;
       }
 
@@ -147,7 +142,7 @@ public final class IntCharSet {
       return;
     }
 
-    intervals.add(new Interval(interval));
+    intervals.add(Interval.copyOf(interval));
   }
 
   /**

--- a/jflex/src/main/java/jflex/Interval.java
+++ b/jflex/src/main/java/jflex/Interval.java
@@ -34,8 +34,9 @@ public final class Interval {
     this.end = end;
   }
 
-  public static Interval copyOf(Interval other) {
-    return new Interval(other.start, other.end);
+  public Interval(Interval other) {
+    this.start = other.start;
+    this.end = other.end;
   }
 
   /**

--- a/jflex/src/main/java/jflex/Interval.java
+++ b/jflex/src/main/java/jflex/Interval.java
@@ -58,9 +58,7 @@ public final class Interval {
     return this.start <= other.start && this.end >= other.end;
   }
 
-  /**
-   * Returns {@code true} if {@code o} is an interval with the same borders.
-   */
+  /** Returns {@code true} if {@code o} is an interval with the same borders. */
   @Override
   public boolean equals(Object o) {
     if (o == this) return true;
@@ -111,9 +109,9 @@ public final class Interval {
   /**
    * Returns a String representation of this interval.
    *
-   * @return a string "{@code [start-end]}" or "{@code [start]}" (if there is only one
-   *     character in the interval) where {@code start} and {@code end} are either a number
-   *     (the character code) or something of the from {@code 'a'}.
+   * @return a string "{@code [start-end]}" or "{@code [start]}" (if there is only one character in
+   *     the interval) where {@code start} and {@code end} are either a number (the character code)
+   *     or something of the from {@code 'a'}.
    */
   public String toString() {
     StringBuilder result = new StringBuilder("[");

--- a/jflex/src/main/java/jflex/Interval.java
+++ b/jflex/src/main/java/jflex/Interval.java
@@ -13,12 +13,15 @@ package jflex;
  * An interval of characters with basic operations.
  *
  * @author Gerwin Klein
+ * @author Régis Décamps
  * @version JFlex 1.7.1-SNAPSHOT
  */
 public final class Interval {
 
-  /* start and end of the interval */
-  public int start, end;
+  /** Start of the interval. */
+  public int start;
+  /** End of the interval. */
+  public int end;
 
   /**
    * Construct a new interval from {@code start</code> to <code>end}.
@@ -31,21 +34,15 @@ public final class Interval {
     this.end = end;
   }
 
-  /**
-   * Copy constructor.
-   *
-   * @param other a {@link jflex.Interval} object.
-   */
-  public Interval(Interval other) {
-    this.start = other.start;
-    this.end = other.end;
+  public static Interval copyOf(Interval other) {
+    return new Interval(other.start, other.end);
   }
 
   /**
-   * Return {@code true</code> iff <code>point} is contained in this interval.
+   * Returns {@code true} iff {@code point} is contained in this interval.
    *
    * @param point the character to check
-   * @return whether the codepoint is contained in the interval.
+   * @return whether the code point is contained in the interval.
    */
   public boolean contains(int point) {
     return start <= point && end >= point;
@@ -62,16 +59,25 @@ public final class Interval {
   }
 
   /**
-   * {@inheritDoc}
-   *
-   * <p>Return {@code true</code> if <code>o} is an interval with the same borders.
+   * Returns {@code true} if {@code o} is an interval with the same borders.
    */
+  @Override
   public boolean equals(Object o) {
     if (o == this) return true;
     if (!(o instanceof Interval)) return false;
 
     Interval other = (Interval) o;
     return other.start == this.start && other.end == this.end;
+  }
+
+  @Override
+  public int hashCode() {
+    int h = 1;
+    h *= 1000003;
+    h ^= start;
+    h *= 1000003;
+    h ^= end;
+    return h;
   }
 
   /**
@@ -99,14 +105,14 @@ public final class Interval {
    */
   private static boolean isPrintable(int c) {
     // fixme: should make unicode test here
-    return c > 31 && c < 127;
+    return 31 < c && c < 127;
   }
 
   /**
-   * Get a String representation of this interval.
+   * Returns a String representation of this interval.
    *
-   * @return a string {@code "[start-end]"</code> or <code>"[start]"} (if there is only one
-   *     character in the interval) where {@code start</code> and <code>end} are either a number
+   * @return a string "{@code [start-end]}" or "{@code [start]}" (if there is only one
+   *     character in the interval) where {@code start} and {@code end} are either a number
    *     (the character code) or something of the from {@code 'a'}.
    */
   public String toString() {

--- a/jflex/src/main/java/jflex/Main.java
+++ b/jflex/src/main/java/jflex/Main.java
@@ -333,7 +333,7 @@ public class Main {
     for (String value : propertyValues) {
       propertyValuesToAliases.put(value, new TreeSet<String>());
     }
-    for (int i = 0; i < propertyValueAliases.length; i += 2) {
+    for (int i = 0; i < propertyValueAliases.length - 1; i += 2) {
       String alias = propertyValueAliases[i];
       String value = propertyValueAliases[i + 1];
       SortedSet<String> aliases = propertyValuesToAliases.get(value);

--- a/jflex/src/main/java/jflex/Main.java
+++ b/jflex/src/main/java/jflex/Main.java
@@ -9,13 +9,15 @@
 
 package jflex;
 
+import static jflex.Options.encoding;
+
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -33,6 +35,7 @@ import jflex.unicode.UnicodeProperties;
  * parsing the commandline, getting input files, starting up the GUI if necessary, etc.
  *
  * @author Gerwin Klein
+ * @author Régis Décamps
  * @version JFlex 1.7.1-SNAPSHOT
  */
 public class Main {
@@ -60,11 +63,12 @@ public class Main {
 
     try {
       Out.println(ErrorMessages.READING, inputFile.toString());
-      inputReader = new InputStreamReader(new FileInputStream(inputFile), Options.encoding);
+      inputReader =
+          new InputStreamReader(Files.newInputStream(Paths.get(inputFile.toString())), encoding);
       scanner = new LexScan(inputReader);
       scanner.setFile(inputFile);
       parser = new LexParse(scanner);
-    } catch (FileNotFoundException e) {
+    } catch (IOException e) {
       Out.error(ErrorMessages.CANNOT_OPEN, inputFile.toString());
       throw new GeneratorException();
     }

--- a/jflex/src/main/java/jflex/Skeleton.java
+++ b/jflex/src/main/java/jflex/Skeleton.java
@@ -99,8 +99,7 @@ public class Skeleton {
 
     Out.println(ErrorMessages.READING_SKEL, skeletonFile.toString());
 
-    try {
-      BufferedReader reader = new BufferedReader(new FileReader(skeletonFile));
+    try (BufferedReader reader = new BufferedReader(new FileReader(skeletonFile))) {
       readSkel(reader);
     } catch (IOException e) {
       Out.error(ErrorMessages.SKEL_IO_ERROR);
@@ -186,8 +185,7 @@ public class Skeleton {
       throw new GeneratorException();
     }
 
-    try {
-      InputStreamReader reader = new InputStreamReader(url.openStream());
+    try (InputStreamReader reader = new InputStreamReader(url.openStream())) {
       readSkel(new BufferedReader(reader));
     } catch (IOException e) {
       Out.error(ErrorMessages.SKEL_IO_ERROR_DEFAULT);

--- a/jflex/src/main/java/jflex/Skeleton.java
+++ b/jflex/src/main/java/jflex/Skeleton.java
@@ -8,13 +8,16 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 package jflex;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.PrintWriter;
 import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -99,7 +102,8 @@ public class Skeleton {
 
     Out.println(ErrorMessages.READING_SKEL, skeletonFile.toString());
 
-    try (BufferedReader reader = new BufferedReader(new FileReader(skeletonFile))) {
+    try (BufferedReader reader =
+        Files.newBufferedReader(Paths.get(skeletonFile.toString()), UTF_8)) {
       readSkel(reader);
     } catch (IOException e) {
       Out.error(ErrorMessages.SKEL_IO_ERROR);

--- a/jflex/src/main/java/jflex/StateSet.java
+++ b/jflex/src/main/java/jflex/StateSet.java
@@ -250,6 +250,9 @@ public final class StateSet {
 
   /** {@inheritDoc} */
   public boolean equals(Object b) {
+    if (!(b instanceof StateSet)) {
+      return false;
+    }
 
     int i = 0;
     int l1, l2;

--- a/testsuite/jflex-testsuite-maven-plugin/src/main/java/jflextest/CustomClassLoader.java
+++ b/testsuite/jflex-testsuite-maven-plugin/src/main/java/jflextest/CustomClassLoader.java
@@ -2,10 +2,11 @@ package jflextest;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.StringTokenizer;
@@ -134,8 +135,7 @@ public class CustomClassLoader extends ClassLoader {
   private byte[] loadFileData(String path, String fileName) {
     File file = new File(path, fileName);
     if (file.canRead()) {
-      try {
-        FileInputStream stream = new FileInputStream(file);
+      try (InputStream stream = Files.newInputStream(Paths.get(file.toString()))) {
         ByteArrayOutputStream out = new ByteArrayOutputStream(1000);
         byte[] b = new byte[1000];
         int n;
@@ -144,7 +144,7 @@ public class CustomClassLoader extends ClassLoader {
         out.close();
         return out.toByteArray();
       } catch (IOException e) {
-        // ignore, maybe another path item succeds
+        // ignore, maybe another path item succeeds
       }
     }
     return null;
@@ -166,7 +166,7 @@ public class CustomClassLoader extends ClassLoader {
     File file = new File(path, name);
     if (file.canRead()) {
       try {
-        return new FileInputStream(file);
+        return Files.newInputStream(Paths.get(file.toString()));
       } catch (IOException e) {
         return null;
       }

--- a/testsuite/jflex-testsuite-maven-plugin/src/main/java/jflextest/TestCase.java
+++ b/testsuite/jflex-testsuite-maven-plugin/src/main/java/jflextest/TestCase.java
@@ -2,12 +2,14 @@ package jflextest;
 
 import com.google.common.collect.ImmutableList;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
+import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.StringReader;
 import java.io.UnsupportedEncodingException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -281,17 +283,13 @@ public class TestCase {
     if (expected.exists()) {
       DiffStream check = new DiffStream();
       String diff;
-      try {
+      try (InputStreamReader expectedContent =
+          new InputStreamReader(
+              Files.newInputStream(Paths.get(expected.toString())), outputFileEncoding)) {
         diff =
-            check.diff(
-                jflexDiff,
-                new StringReader(classExecResult.getOutput()),
-                new InputStreamReader(new FileInputStream(expected), outputFileEncoding));
-      } catch (FileNotFoundException e) {
+            check.diff(jflexDiff, new StringReader(classExecResult.getOutput()), expectedContent);
+      } catch (IOException e) {
         System.out.println("Error opening file " + expected);
-        throw new TestFailException();
-      } catch (UnsupportedEncodingException e) {
-        System.out.println("Unsupported encoding '" + outputFileEncoding + "'");
         throw new TestFailException();
       }
       if (diff != null) {


### PR DESCRIPTION
From https://lgtm.com/projects/g/jflex-de/jflex/alerts/

- Class Interval overrides equals but not hashCode.
- Class IntCharSet overrides equals but not hashCode.
- StateSet: equals() method does not seem to check argument type.
- Main: array access might be out of bounds, as the index might be equal to the array length.
- Main: This FileInputStream is not always closed on method exit.
- Skeleton: This FileReader is not always closed on method exit.
- Skeleton: The FileInputStream and FileOutputStream classes contains a finalizer method which will cause garbage collection pauses. See JDK-8080225 for details.