### PR TITLE
Fix Aggregated java sources

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,8 @@ matrix:
     - scripts/mvn-site.sh
     - scripts/mvn-aggregate-srcs.sh
     after_success: scripts/send-code-coverage.sh
-    env: TEST_SUITE=unit
+    env:
+    - PUBLISH_SOURCES=true
     language: generic
   - name: "📝 Regression tests"
     script:
@@ -116,6 +117,5 @@ deploy:
     - master
     - travis
     condition:
-    - $TEST_SUITE = unit
-    - $TRAVIS_JDK_VERSION = openjdk9
+    - $PUBLISH_SOURCES
   script: ./scripts/deploy-source-code.sh


### PR DESCRIPTION
The deploy phase didn't trigger for the past few days. Missing:
- commit a9406b60ddf66ec63a9330d9a54547cb02e5e67c (bump maven deps)
- commit 47ffc864b8979dc5c62496b3fa92a55de11ac743 (add jacoco)
- commit b4ecdc5de3e34416fcd79c39b8173e18d6178f07 (shashify "source:" in header)
- commit dedd07459972571d51665a6ac0d4a5cecb54f01f (fix lgtm code warnings)
- commit f4b8ac11abc2f55f8280b42d4ba70c270ddae52f (replace `<code>` by `{@code }`)
 