### PR TITLE
Add a genrule for cup

### DIFF
--- a/cup/BUILD
+++ b/cup/BUILD
@@ -2,6 +2,15 @@ package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # GPL-compatible
 
+java_binary(
+    name = "cup_bin",
+    main_class = "java_cup.Main",
+    runtime_deps = [
+        ":cup",
+        ":cup_runtime",
+    ],
+)
+
 java_import(
     name = "cup",
     jars = ["cup/target/cup-11b.jar"],

--- a/cup/README.md
+++ b/cup/README.md
@@ -11,4 +11,15 @@ Home directory and parent POM of 2 artefacts:
 Note that this code is excluded from many rules of our codebase,
 for instance google-java-format is not applied.
 
+
+## Bazel rule
+
+    load("//cup:cup.bzl", "cup")
+    
+    cup(
+      name = "rule_name",
+      src = "spec.cup",
+     )
+
+
 [cup]: http://www2.cs.tum.edu/projects/cup/

--- a/cup/cup.bzl
+++ b/cup/cup.bzl
@@ -1,7 +1,7 @@
 """Bazel rules for cup. """
 
 # CUP can only read from stdin, which Skylark rules don't support. Use a genrule for now.
-def cup(name, srcs, parser = "Parser", symbols = "Symbols", interface = False):
+def cup(name, src, parser = "Parser", symbols = "Symbols", interface = False):
     """Generate a parser with CUP.
 
     Args:
@@ -17,7 +17,7 @@ def cup(name, srcs, parser = "Parser", symbols = "Symbols", interface = False):
     cmd = ("$(location //cup:cup_bin) -destdir $(@D) " + opts + " < $<")
     native.genrule(
         name = name,
-        srcs = srcs,
+        srcs = [src],
         tools = ["//cup:cup_bin"],
         outs = [parser + ".java", symbols + ".java"],
         cmd = cmd,

--- a/cup/cup.bzl
+++ b/cup/cup.bzl
@@ -1,0 +1,24 @@
+"""Bazel rules for cup. """
+
+# CUP can only read from stdin, which Skylark rules don't support. Use a genrule for now.
+def cup(name, srcs, parser = "Parser", symbols = "Symbols", interface = False):
+    """Generate a parser with CUP.
+
+    Args:
+      name: name of the rule
+      srcs: list of cup specifications
+      parser: name of the generated parser class
+      symbols: name of the generated symbols class
+      interface: whether to generate an interface
+    """
+    opts = "-parser {parser} -symbols {symbols}".format(parser = parser, symbols = symbols)
+    if interface:
+        opts = opts + " -interface"
+    cmd = ("$(location //cup:cup_bin) -destdir $(@D) " + opts + " < $<")
+    native.genrule(
+        name = name,
+        srcs = srcs,
+        tools = ["//cup:cup_bin"],
+        outs = [parser + ".java", symbols + ".java"],
+        cmd = cmd,
+    )

--- a/cup/sample-project/BUILD
+++ b/cup/sample-project/BUILD
@@ -1,0 +1,6 @@
+load("//cup:cup.bzl", "cup")
+
+cup(
+    name = "gen_parser",
+    srcs = ["src/main/cup/calculator.cup"],
+)

--- a/cup/sample-project/BUILD
+++ b/cup/sample-project/BUILD
@@ -2,5 +2,5 @@ load("//cup:cup.bzl", "cup")
 
 cup(
     name = "gen_parser",
-    srcs = ["src/main/cup/calculator.cup"],
+    src = "src/main/cup/calculator.cup",
 )


### PR DESCRIPTION
Macro that wraps a genrule to generate a Java parser from a CUP specification.

I don't think it's possible to use a Skylark rule, because cup reads from stdin.
