### PR TITLE
Build JFlex (core) with Bazel

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -25,11 +25,10 @@ jflex_deps()
 #)
 http_archive(
     name = "bazel_pandoc",
+    sha256 = "0dd9d0d44658d46a96c36caba25f7ce9f119a6883c3219f61b76c11cfdc83c8f",
     strip_prefix = "bazel_pandoc-0.1.1",
     url = "https://github.com/regisd/bazel_pandoc/archive/v0.1.1.tar.gz",
-    sha256 = "0dd9d0d44658d46a96c36caba25f7ce9f119a6883c3219f61b76c11cfdc83c8f",
 )
-
 
 load("@bazel_pandoc//:repositories.bzl", "pandoc_repositories")
 
@@ -48,16 +47,6 @@ load("@bazel_latex//:repositories.bzl", "latex_repositories")
 latex_repositories()
 
 # Third-party depenencies
+load("//third_party:deps.bzl", "third_party_deps")
 
-maven_jar(
-    name = "com_google_truth_truth",
-    artifact = "com.google.truth:truth:0.36",
-    repository = "http://jcenter.bintray.com/",
-)
-
-maven_jar(
-    name = "com_google_guava_guava",
-    artifact = "com.google.guava:guava:jar:26.0-jre",
-    repository = "http://jcenter.bintray.com/",
-)
-
+third_party_deps()

--- a/cup/BUILD
+++ b/cup/BUILD
@@ -7,13 +7,13 @@ java_binary(
     main_class = "java_cup.Main",
     runtime_deps = [
         ":cup",
-        ":cup_runtime",
     ],
 )
 
+# This is the full Java CUP (with runtime)
 java_import(
     name = "cup",
-    jars = ["cup/target/cup-11b.jar"],
+    jars = ["cup/java-cup-11b.jar"],
 )
 
 alias(

--- a/jflex/BUILD
+++ b/jflex/BUILD
@@ -1,5 +1,8 @@
 package(default_visibility = ["//visibility:public"])
 
+load("//cup:cup.bzl", "cup")
+load("@jflex_rules//jflex:jflex.bzl", "jflex")
+
 java_binary(
     name = "jflex_bin",
     main_class = "jflex.Main",
@@ -9,7 +12,32 @@ java_binary(
     ],
 )
 
-java_import(
+java_library(
     name = "jflex",
-    jars = ["target/jflex-1.7.1-SNAPSHOT.jar"],
+    srcs = glob(["src/main/java/**/*.java"]) + [
+        ":gen_parser",
+        ":gen_scanner",
+    ],
+    resources = glob(["src/main/resources/**"]),
+    visibility = ["//visibility:public"],
+    deps = [
+        "//cup",
+        "//third_party/org/apache/ant",
+    ],
+)
+
+cup(
+    name = "gen_parser",
+    src = "src/main/cup/LexParse.cup",
+    interface = True,
+    parser = "LexParse",
+    symbols = "sym",
+)
+
+# Use bootstrap version defined in @jflex_rules
+jflex(
+    name = "gen_scanner",
+    srcs = ["src/main/jflex/LexScan.flex"],
+    outputs = ["LexScan.java"],
+    skeleton = "src/main/jflex/skeleton.nested",
 )

--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -1,0 +1,1 @@
+# Defines the root //third_party package

--- a/third_party/deps.bzl
+++ b/third_party/deps.bzl
@@ -1,6 +1,12 @@
 # Please keep deps in alphabetical order
 def third_party_deps():
     native.maven_jar(
+        name = "org_apache_ant_ant",
+        artifact = "org.apache.ant:ant:1.7.0",
+        repository = "https://jcenter.bintray.com/",
+        sha1 = "9746af1a485e50cf18dcb232489032a847067066",
+    )
+    native.maven_jar(
         name = "com_google_guava_guava",
         artifact = "com.google.guava:guava:jar:26.0-jre",
         repository = "http://jcenter.bintray.com/",

--- a/third_party/deps.bzl
+++ b/third_party/deps.bzl
@@ -1,0 +1,12 @@
+# Please keep deps in alphabetical order
+def third_party_deps():
+    native.maven_jar(
+        name = "com_google_guava_guava",
+        artifact = "com.google.guava:guava:jar:26.0-jre",
+        repository = "http://jcenter.bintray.com/",
+    )
+    native.maven_jar(
+        name = "com_google_truth_truth",
+        artifact = "com.google.truth:truth:0.36",
+        repository = "http://jcenter.bintray.com/",
+    )

--- a/third_party/org/apache/ant/BUILD
+++ b/third_party/org/apache/ant/BUILD
@@ -1,0 +1,8 @@
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
+
+alias(
+    name = "ant",
+    actual = "@org_apache_ant_ant//jar",
+)


### PR DESCRIPTION
* Build JFlex with Bazel
  - generate parser with the new cup macro (#442)
  - generate scanner with public jflex rule
  - build java lib
* add third/party/org/apache/ant
  - also move `maven_import` of third_party dependencies in their own file
