### PR TITLE
Split bazel build packages for gui, cli and anttask

### DIFF
--- a/jflex/BUILD
+++ b/jflex/BUILD
@@ -12,7 +12,7 @@ java_binary(
     name = "jflex_bin",
     main_class = "jflex.Main",
     runtime_deps = [
-        ":jflex",
+        "//jflex/src/main/java/jflex:jflex_ui",
         "//cup:cup_runtime",
     ],
 )

--- a/jflex/src/main/java/jflex/BUILD
+++ b/jflex/src/main/java/jflex/BUILD
@@ -1,8 +1,10 @@
 package(default_visibility = ["//visibility:public"])
 
+LAUNCHER_SRCS = ["Main.java"]
+
 java_library(
     name = "jflex",
-    srcs = glob(["**/*.java"]) + [
+    srcs = glob(["**/*.java"], exclude = LAUNCHER_SRCS) + [
         "//jflex:gen_parser",
         "//jflex:gen_scanner",
     ],
@@ -11,6 +13,16 @@ java_library(
         "//cup:cup_runtime",
         "//jflex/src/main/java/jflex/io",
         "//jflex/src/main/java/jflex/performance",
-        "//third_party/org/apache/ant",
+    ],
+)
+
+# cli, gui, and ant task
+java_library(
+    name = "jflex_ui",
+    srcs = LAUNCHER_SRCS,
+    deps = [
+        ":jflex",
+        "//jflex/src/main/java/jflex/anttask",
+        "//jflex/src/main/java/jflex/gui",
     ],
 )

--- a/jflex/src/main/java/jflex/anttask/BUILD
+++ b/jflex/src/main/java/jflex/anttask/BUILD
@@ -1,0 +1,10 @@
+package(default_visibility = ["//jflex:visibility"])
+
+java_library(
+    name = "anttask",
+    srcs = glob(["*.java"]),
+    deps = [
+        "//jflex",
+        "//third_party/org/apache/ant",
+    ],
+)

--- a/jflex/src/main/java/jflex/gui/BUILD
+++ b/jflex/src/main/java/jflex/gui/BUILD
@@ -1,0 +1,7 @@
+package(default_visibility = ["//jflex:visibility"])
+
+java_library(
+    name = "gui",
+    srcs = glob(["*.java"]),
+    deps = ["//jflex"],
+)


### PR DESCRIPTION
With this change
* //jflex is the core jflex library
* //jflex:jflex_bin adds the cli (jflex.Main), the gui and the ant task
