### PR TITLE
Fix compile.sh on aggregated-java-sources

### DIFF
--- a/scripts/compile-aggregated-java-sources.sh
+++ b/scripts/compile-aggregated-java-sources.sh
@@ -2,7 +2,7 @@
 # Compiles the aggregated Java sources.
 # Meant to be execute in https://github.com/jflex-de/jflex/tree/aggregated-java-sources
 # Source: https://github.com/jflex-de/jflex/blob/master/scripts/compile-aggregated-sources.sh
-mkdir lib
+mkdir -p lib
 REPO=https://repo.maven.apache.org/maven2
 CP=""
 mvnget() {
@@ -11,7 +11,7 @@ mvnget() {
   ls lib/$jarfile
   if [ -f lib/$jarfile ]; then
     echo "Using cached $jarfile"
-    return "$jarfile"
+    return 0
   fi
   wget $REPO/$dep -P lib
   CP="$CP:lib/$jarfile"


### PR DESCRIPTION
./compile.sh: 14: return: Illegal number: ant-1.7.0.jar