### PR TITLE
Remove override of --ram_utilization_factor

### DIFF
--- a/.ci.bazelrc
+++ b/.ci.bazelrc
@@ -3,7 +3,6 @@ import %workspace%/.bazelrc
 # This is from Bazel's former travis setup, to avoid blowing up the RAM usage.
 startup --host_jvm_args=-Xms2000m
 startup --host_jvm_args=-Xmx3000m
-test --ram_utilization_factor=10
 
 # This is so we understand failures better
 build --verbose_failures


### PR DESCRIPTION
The default is 67 (i.e. bazel uses 67% of host RAM) and I thinks that's fine. The reason no reason to reduce parallelism and use 10% only.