### PR TITLE
Add BUILD targets for Unicode data

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -50,3 +50,8 @@ latex_repositories()
 load("//third_party:deps.bzl", "third_party_deps")
 
 third_party_deps()
+
+# Unicode character definitions (UCD) from Unicode.org
+load("//third_party/unicode:unicode.bzl", "unicode_deps")
+
+unicode_deps()

--- a/third_party/unicode/BUILD
+++ b/third_party/unicode/BUILD
@@ -1,0 +1,65 @@
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
+
+exports_files(["LICENSE"])
+
+filegroup(
+    name = "ucd_1",
+    srcs = [
+        "@ucd_1_UnicodeData_1_1_5_txt//file",
+    ],
+)
+
+filegroup(
+    name = "ucd_2",
+    srcs = [
+        "@ucd_2_Blocks_2_txt//file",
+        "@ucd_2_PropList_2_1_9_txt//file",
+        "@ucd_2_UnicodeData_2_1_9_txt//file",
+    ],
+)
+
+filegroup(
+    name = "ucd_3",
+    srcs = [
+        "@ucd_3_Blocks_3_2_0_txt//file",
+        "@ucd_3_DerivedCoreProperties_3_2_0_txt//file",
+        "@ucd_3_LineBreak_3_2_0_txt//file",
+        "@ucd_3_PropList_3_2_0_txt//file",
+        "@ucd_3_PropertyAliases_3_2_0_txt//file",
+        "@ucd_3_PropertyValueAliases_3_2_0_txt//file",
+        "@ucd_3_Scripts_3_2_0_txt//file",
+        "@ucd_3_UnicodeData_3_2_0_txt//file",
+    ],
+)
+
+alias(
+    name = "ucd_4",
+    actual = "@ucd_4//:files",
+)
+
+alias(
+    name = "ucd_5",
+    actual = "@ucd_5//:files",
+)
+
+alias(
+    name = "ucd_6",
+    actual = "@ucd_6//:files",
+)
+
+alias(
+    name = "ucd_7",
+    actual = "@ucd_7//:files",
+)
+
+alias(
+    name = "ucd_8",
+    actual = "@ucd_8//:files",
+)
+
+alias(
+    name = "ucd_9",
+    actual = "@ucd_9//:files",
+)

--- a/third_party/unicode/LICENSE
+++ b/third_party/unicode/LICENSE
@@ -1,0 +1,41 @@
+NOTICE TO USER: Carefully read the following legal agreement.
+BY DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING UNICODE INC.'S
+DATA FILES ("DATA FILES"), AND/OR SOFTWARE ("SOFTWARE"),
+YOU UNEQUIVOCALLY ACCEPT, AND AGREE TO BE BOUND BY, ALL OF THE
+TERMS AND CONDITIONS OF THIS AGREEMENT.
+IF YOU DO NOT AGREE, DO NOT DOWNLOAD, INSTALL, COPY, DISTRIBUTE OR USE
+THE DATA FILES OR SOFTWARE.
+
+COPYRIGHT AND PERMISSION NOTICE
+
+Copyright © 1991-2018 Unicode, Inc. All rights reserved.
+Distributed under the Terms of Use in http://www.unicode.org/copyright.html.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of the Unicode data files and any associated documentation
+(the "Data Files") or Unicode software and any associated documentation
+(the "Software") to deal in the Data Files or Software
+without restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, and/or sell copies of
+the Data Files or Software, and to permit persons to whom the Data Files
+or Software are furnished to do so, provided that either
+(a) this copyright and permission notice appear with all copies
+of the Data Files or Software, or
+(b) this copyright and permission notice appear in associated
+Documentation.
+
+THE DATA FILES AND SOFTWARE ARE PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT OF THIRD PARTY RIGHTS.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS INCLUDED IN THIS
+NOTICE BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT OR CONSEQUENTIAL
+DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE,
+DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+PERFORMANCE OF THE DATA FILES OR SOFTWARE.
+
+Except as contained in this notice, the name of a copyright holder
+shall not be used in advertising or otherwise to promote the sale,
+use or other dealings in these Data Files or Software without prior
+written authorization of the copyright holder.

--- a/third_party/unicode/README.md
+++ b/third_party/unicode/README.md
@@ -1,0 +1,36 @@
+# Unicode Character Definitions
+
+This package provides a Skylark rule to 
+import the Unicode character definitions (UCD) from unicode.org.
+
+
+For further information about data files please see:
+
+Unicode Character Database
+	http://www.unicode.org/ucd/
+
+Terms of Use
+	http://www.unicode.org/copyright.html
+
+
+## How to generate Unicode properties?
+
+### Add the source files in the Bazel Workspace
+
+Edit `third_party/unicode/unicode.bzl` and add an `http_archive`.
+The `ucd_zip_version` is a convenient way to do this. For instance:
+
+```python
+    ucd_zip_version(
+        name = "ucd_9",
+        version = "9.0.0",
+        sha256 = "df9e028425816fd5117eaea7173704056f88f7cd030681e457c6f3827f9390ec",
+        extra_files = ["ScriptExtensions.txt"],
+    )
+```
+
+### Generate the UnicodeProperties.java
+
+Run the generator with all versions
+
+    bazel run //java/ucd_generator:Main 1.1=ucd_1 … 9.0=ucd_9

--- a/third_party/unicode/unicode.bzl
+++ b/third_party/unicode/unicode.bzl
@@ -1,0 +1,120 @@
+# Workspace macro to import all UCD
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file")
+
+BUILD_UCD_ZIP = """# Content of a UCD archive
+filegroup(
+  name = "files",
+  srcs = [
+    "Blocks.txt",
+    "DerivedCoreProperties.txt",
+    "LineBreak.txt",
+    "PropList.txt",
+    "PropertyAliases.txt",
+    "PropertyValueAliases.txt",
+    "Scripts.txt",
+    "UnicodeData.txt",
+    "auxiliary/GraphemeBreakProperty.txt",
+    "auxiliary/SentenceBreakProperty.txt",
+    "auxiliary/WordBreakProperty.txt",
+    {extra_files}
+  ],
+  visibility = ["//visibility:public"],
+)
+"""
+
+def unicode_urls(path):
+    return [
+        # the Unicode.org site is extremely slow. Prefer a mirror.
+        "http://ftp.lanet.lv/ftp/mirror/unicode" + path,
+        "http://www.unicode.org/Public" + path,
+    ]
+
+def ucd_zip_version(name, version, sha256, extra_files = []):
+    """Macro to import the UCD for a given unicode version, by individual files.
+
+    Recommended for v4 and later.
+    """
+    path = "/zipped/" + version + "/UCD.zip"
+    http_archive(
+        name = name,
+        build_file_content = BUILD_UCD_ZIP.format(
+            extra_files = "".join(['"{file}",'.format(file = f) for f in extra_files]),
+        ),
+        sha256 = sha256,
+        urls = unicode_urls(path),
+    )
+
+def ucd_version(name, version, files):
+    """Macro to import the UCD for a given unicode version, by individual files."""
+    for fn, sha in files.items():
+        # TODO All files
+        ucd_file(
+            name = name,
+            version = version,
+            file = fn,
+            sha256 = sha,
+        )
+
+def ucd_file(name, version, file, sha256):
+    bzl_name = name + "_" + file.replace(".", "_").replace("-", "_")
+    path = "/" + version + "/" + file
+    http_file(
+        name = bzl_name,
+        urls = unicode_urls(path),
+        sha256 = sha256,
+    )
+
+def unicode_deps():
+    ucd_version(name = "ucd_1", version = "1.1-Update", files = {
+        "UnicodeData-1.1.5.txt": "b0aa30303db3c13701967320550952e7368470776e304b52270fdb9256e4bd5b",
+    })
+    ucd_version(name = "ucd_2", version = "2.1-Update4", files = {
+        "Blocks-2.txt": "6a6653752ce1d8bd1f7a7777001d24d5008a58d138e03f11f9399f2de13fc81c",
+        "PropList-2.1.9.txt": "c794fe1d60fbdb0ab8c76a151f56c3d4e51c57e0f779914a767f11bc213630f6",
+        "UnicodeData-2.1.9.txt": "3dcee8b6b68151956fb799e4445c4e8948c0f4257d241b193ec3881b08c48137",
+    })
+    ucd_version(name = "ucd_3", version = "3.2-Update", files = {
+        "Blocks-3.2.0.txt": "8b367b02089762e753a0b5554182a6a132b9394431c0fe9f1dffb7a3338d86b9",
+        "DerivedCoreProperties-3.2.0.txt": "787419dde91701018d7ad4f47432eaa55af14e3fe3fe140a11e4bbf3db18bb4c",
+        "LineBreak-3.2.0.txt": "d693ef2a603d07e20b769ef8ba29afca39765588a03e3196294e5be8638ca735",
+        "PropList-3.2.0.txt": "e6f4899305fd0a2771529671549dc2d75b502f4346e23b711f7f8b024d89a5f2",
+        "PropertyAliases-3.2.0.txt": "8b9b07b0cb9f2d4bd3a27f3284af9dbf00984af53f9b5fd48f7f10f80d29f7c1",
+        "PropertyValueAliases-3.2.0.txt": "c239cdc4a71c4d297901f6e6d377eed1c4547d3a12cb7afc3daf29098d94df28",
+        "Scripts-3.2.0.txt": "16b3db9e2d1b87600831209df02ecff41aeaf0c2aab0f034684fda14189c1aa5",
+        "UnicodeData-3.2.0.txt": "5e444028b6e76d96f9dc509609c5e3222bf609056f35e5fcde7e6fb8a58cd446",
+    })
+    ucd_zip_version(
+        name = "ucd_4",
+        version = "4.1.0",
+        sha256 = "1aa4041a36de1ef94b66beeb152ebd967f5f9be62f8b4ef382909258ef99b732",
+    )
+    ucd_zip_version(
+        name = "ucd_5",
+        version = "5.2.0",
+        sha256 = "3d7a2467d6ee2533de545d833b3cd1cc2488f198e38d7b8b42adc67023a0c646",
+    )
+    ucd_zip_version(
+        name = "ucd_6",
+        version = "6.3.0",
+        sha256 = "2d3c6c51b5821e821881b13694eccb78812d493762c41e9c95c31a7686ed3823",
+        extra_files = ["ScriptExtensions.txt"],
+    )
+    ucd_zip_version(
+        name = "ucd_7",
+        version = "7.0.0",
+        sha256 = "9c9d92ec9f011691d6d22d2c2d3e5825f50e4f8d6f85c2c2bc01705f085e2af6",
+        extra_files = ["ScriptExtensions.txt"],
+    )
+    ucd_zip_version(
+        name = "ucd_8",
+        version = "8.0.0",
+        sha256 = "e3959c0b96c5ea7ff118254b55e1a752c2a28170b3404ba6bb5ab2c58536ce2e",
+        extra_files = ["ScriptExtensions.txt"],
+    )
+    ucd_zip_version(
+        name = "ucd_9",
+        version = "9.0.0",
+        sha256 = "df9e028425816fd5117eaea7173704056f88f7cd030681e457c6f3827f9390ec",
+        extra_files = ["ScriptExtensions.txt"],
+    )


### PR DESCRIPTION
Add the Unicode Character Definitions (UCD) for the versions JFlex supports.

Use http zip archive when it exists (version >4)
Use direct http file reference otherwise (version 1-3)