### PR TITLE
Add all deprecated Unicode major.minor versions

### DIFF
--- a/third_party/unicode/BUILD
+++ b/third_party/unicode/BUILD
@@ -5,18 +5,27 @@ licenses(["notice"])
 exports_files(["LICENSE"])
 
 filegroup(
-    name = "ucd_1",
+    name = "ucd_1_1_5",
     srcs = [
         "@ucd_1_UnicodeData_1_1_5_txt//file",
     ],
 )
 
 filegroup(
-    name = "ucd_2",
+    name = "ucd_2_0_14",
     srcs = [
-        "@ucd_2_Blocks_2_txt//file",
-        "@ucd_2_PropList_2_1_9_txt//file",
-        "@ucd_2_UnicodeData_2_1_9_txt//file",
+        "@ucd_2_0_14_Blocks_1_txt//file",
+        "@ucd_2_0_14_PropList_2_0_14_txt//file",
+        "@ucd_2_0_14_UnicodeData_2_0_14_txt//file",
+    ],
+)
+
+filegroup(
+    name = "ucd_2_1_9",
+    srcs = [
+        "@ucd_2_1_9_Blocks_2_txt//file",
+        "@ucd_2_1_9_PropList_2_1_9_txt//file",
+        "@ucd_2_1_9_UnicodeData_2_1_9_txt//file",
     ],
 )
 

--- a/third_party/unicode/BUILD
+++ b/third_party/unicode/BUILD
@@ -30,16 +30,38 @@ filegroup(
 )
 
 filegroup(
-    name = "ucd_3",
+    name = "ucd_3_0_1",
     srcs = [
-        "@ucd_3_Blocks_3_2_0_txt//file",
-        "@ucd_3_DerivedCoreProperties_3_2_0_txt//file",
-        "@ucd_3_LineBreak_3_2_0_txt//file",
-        "@ucd_3_PropList_3_2_0_txt//file",
-        "@ucd_3_PropertyAliases_3_2_0_txt//file",
-        "@ucd_3_PropertyValueAliases_3_2_0_txt//file",
-        "@ucd_3_Scripts_3_2_0_txt//file",
-        "@ucd_3_UnicodeData_3_2_0_txt//file",
+        "@ucd_3_0_0_Blocks_3_txt//file",
+        "@ucd_3_0_0_LineBreak_5_txt//file",
+        "@ucd_3_0_1_PropList_3_0_1_txt//file",
+        "@ucd_3_0_1_UnicodeData_3_0_1_txt//file",
+    ],
+)
+
+filegroup(
+    name = "ucd_3_1_1",
+    srcs = [
+        "@ucd_3_1_0_Blocks_4_txt//file",
+        "@ucd_3_1_0_DerivedCoreProperties_3_1_0_txt//file",
+        "@ucd_3_1_0_LineBreak_6_txt//file",
+        "@ucd_3_1_0_Scripts_3_1_0_txt//file",
+        "@ucd_3_1_0_UnicodeData_3_1_0_txt//file",
+        "@ucd_3_1_1_PropList_3_1_1_txt//file",
+    ],
+)
+
+filegroup(
+    name = "ucd_3_2_0",
+    srcs = [
+        "@ucd_3_2_0_Blocks_3_2_0_txt//file",
+        "@ucd_3_2_0_DerivedCoreProperties_3_2_0_txt//file",
+        "@ucd_3_2_0_LineBreak_3_2_0_txt//file",
+        "@ucd_3_2_0_PropList_3_2_0_txt//file",
+        "@ucd_3_2_0_PropertyAliases_3_2_0_txt//file",
+        "@ucd_3_2_0_PropertyValueAliases_3_2_0_txt//file",
+        "@ucd_3_2_0_Scripts_3_2_0_txt//file",
+        "@ucd_3_2_0_UnicodeData_3_2_0_txt//file",
     ],
 )
 

--- a/third_party/unicode/BUILD
+++ b/third_party/unicode/BUILD
@@ -66,8 +66,8 @@ filegroup(
 )
 
 alias(
-    name = "ucd_4",
-    actual = "@ucd_4//:files",
+    name = "ucd_4_1_0",
+    actual = "@ucd_4_1_0//:files",
 )
 
 alias(

--- a/third_party/unicode/BUILD
+++ b/third_party/unicode/BUILD
@@ -76,8 +76,8 @@ alias(
 )
 
 alias(
-    name = "ucd_6",
-    actual = "@ucd_6//:files",
+    name = "ucd_6_3_0",
+    actual = "@ucd_6_3_0//:files",
 )
 
 alias(

--- a/third_party/unicode/BUILD
+++ b/third_party/unicode/BUILD
@@ -7,7 +7,7 @@ exports_files(["LICENSE"])
 filegroup(
     name = "ucd_1_1_5",
     srcs = [
-        "@ucd_1_UnicodeData_1_1_5_txt//file",
+        "@ucd_1_1_5_UnicodeData_1_1_5_txt//file",
     ],
 )
 

--- a/third_party/unicode/BUILD
+++ b/third_party/unicode/BUILD
@@ -71,8 +71,8 @@ alias(
 )
 
 alias(
-    name = "ucd_5",
-    actual = "@ucd_5//:files",
+    name = "ucd_5_2_0",
+    actual = "@ucd_5_2_0//:files",
 )
 
 alias(

--- a/third_party/unicode/unicode.bzl
+++ b/third_party/unicode/unicode.bzl
@@ -118,7 +118,7 @@ def unicode_deps():
         sha256 = "3d7a2467d6ee2533de545d833b3cd1cc2488f198e38d7b8b42adc67023a0c646",
     )
     ucd_zip_version(
-        name = "ucd_6",
+        name = "ucd_6_3_0",
         version = "6.3.0",
         sha256 = "2d3c6c51b5821e821881b13694eccb78812d493762c41e9c95c31a7686ed3823",
         extra_files = ["ScriptExtensions.txt"],

--- a/third_party/unicode/unicode.bzl
+++ b/third_party/unicode/unicode.bzl
@@ -113,7 +113,7 @@ def unicode_deps():
         sha256 = "1aa4041a36de1ef94b66beeb152ebd967f5f9be62f8b4ef382909258ef99b732",
     )
     ucd_zip_version(
-        name = "ucd_5",
+        name = "ucd_5_2_0",
         version = "5.2.0",
         sha256 = "3d7a2467d6ee2533de545d833b3cd1cc2488f198e38d7b8b42adc67023a0c646",
     )

--- a/third_party/unicode/unicode.bzl
+++ b/third_party/unicode/unicode.bzl
@@ -66,10 +66,15 @@ def ucd_file(name, version, file, sha256):
     )
 
 def unicode_deps():
-    ucd_version(name = "ucd_1", version = "1.1-Update", files = {
+    ucd_version(name = "ucd_1_1_5", version = "1.1-Update", files = {
         "UnicodeData-1.1.5.txt": "b0aa30303db3c13701967320550952e7368470776e304b52270fdb9256e4bd5b",
     })
-    ucd_version(name = "ucd_2", version = "2.1-Update4", files = {
+    ucd_version(name = "ucd_2_0_14", version = "2.0-Update", files = {
+        "Blocks-1.txt": "91b0d41a60af658a73e277f108d3f4959a8ec3f3983654b24c00db3a4e146877",
+        "PropList-2.0.14.txt": "b23b98764b7e3e6eef67c161cd4b247dc1e5bcea3184598cdfc8d6cf83a83e23",
+        "UnicodeData-2.0.14.txt": "fdb15931fefb25d34546c575c6507732a4ac48b4b4148510f46ee0161a84c336",
+    })
+    ucd_version(name = "ucd_2_1_9", version = "2.1-Update4", files = {
         "Blocks-2.txt": "6a6653752ce1d8bd1f7a7777001d24d5008a58d138e03f11f9399f2de13fc81c",
         "PropList-2.1.9.txt": "c794fe1d60fbdb0ab8c76a151f56c3d4e51c57e0f779914a767f11bc213630f6",
         "UnicodeData-2.1.9.txt": "3dcee8b6b68151956fb799e4445c4e8948c0f4257d241b193ec3881b08c48137",

--- a/third_party/unicode/unicode.bzl
+++ b/third_party/unicode/unicode.bzl
@@ -108,7 +108,7 @@ def unicode_deps():
         "UnicodeData-3.2.0.txt": "5e444028b6e76d96f9dc509609c5e3222bf609056f35e5fcde7e6fb8a58cd446",
     })
     ucd_zip_version(
-        name = "ucd_4",
+        name = "ucd_4_1_0",
         version = "4.1.0",
         sha256 = "1aa4041a36de1ef94b66beeb152ebd967f5f9be62f8b4ef382909258ef99b732",
     )

--- a/third_party/unicode/unicode.bzl
+++ b/third_party/unicode/unicode.bzl
@@ -79,7 +79,25 @@ def unicode_deps():
         "PropList-2.1.9.txt": "c794fe1d60fbdb0ab8c76a151f56c3d4e51c57e0f779914a767f11bc213630f6",
         "UnicodeData-2.1.9.txt": "3dcee8b6b68151956fb799e4445c4e8948c0f4257d241b193ec3881b08c48137",
     })
-    ucd_version(name = "ucd_3", version = "3.2-Update", files = {
+    ucd_version(name = "ucd_3_0_0", version = "3.0-Update", files = {
+        "Blocks-3.txt": "b574340ba81a64c2eee69ef37eacd422258a67e6899c068f98f3165ef60e31ea",
+        "LineBreak-5.txt": "a8f29019410364458c30c5a8dad41f9748d07280027eeb808bc4cc7f7c1abc73",
+                        })
+    ucd_version(name = "ucd_3_0_1", version = "3.0-Update1", files = {
+        "PropList-3.0.1.txt": "909eef4adbeddbdddcd9487c856fe8cdbb8912aa8eb315ed7885b6ef65f4dc4c",
+        "UnicodeData-3.0.1.txt": "2aea1fc7d7e64d792fcbd56721fef104a153e2783ab28bcaeb171d9742dd5a24",
+    })
+    ucd_version(name = "ucd_3_1_0", version = "3.1-Update", files = {
+        "Blocks-4.txt": "00cdecb26876e7576abb724e39fafb78be24c2f34fe59b94deb70e8262f7bba5",
+        "DerivedCoreProperties-3.1.0.txt": "337c9bdd2098fd354c80b9aecb18cedf06b7aecb78aa88a1be74b249dedd2e06",
+        "LineBreak-6.txt": "e630bb90aca76ba299f109ee2feaa41ded43c663df9f7a8c4d664e2aabff1017",
+        "Scripts-3.1.0.txt": "23423fca7931ba38c5f19ec588c7de76c15af401e2a71b317d9022c2a717665a",
+        "UnicodeData-3.1.0.txt": "8e57884da0da3a66782b8a6332a601fccbcae9ed0060e12501aca02fa56ffecd",
+    })
+    ucd_version(name = "ucd_3_1_1", version = "3.1-Update1", files = {
+        "PropList-3.1.1.txt": "d8b483e1b1143be208ee6ef9aeeb424f3c19828834c4d2c1427fc9a8d4c64d0e",
+    })
+    ucd_version(name = "ucd_3_2_0", version = "3.2-Update", files = {
         "Blocks-3.2.0.txt": "8b367b02089762e753a0b5554182a6a132b9394431c0fe9f1dffb7a3338d86b9",
         "DerivedCoreProperties-3.2.0.txt": "787419dde91701018d7ad4f47432eaa55af14e3fe3fe140a11e4bbf3db18bb4c",
         "LineBreak-3.2.0.txt": "d693ef2a603d07e20b769ef8ba29afca39765588a03e3196294e5be8638ca735",


### PR DESCRIPTION
Rename filegroup ucd_X to ucd_X_Y_Z.

Based on discussion for PR https://github.com/jflex-de/jflex/pull/526#issuecomment-433750425 Add old unicode versions.