### PR TITLE
Update padoc&latex to latest versions

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -5,7 +5,7 @@
 build_task:
   name: Bazel build and test
   container:
-    image: cirrusci/bazel:latest
+    image: l.gcr.io/google/bazel:latest
   bazel_version_script:
   - bazel --bazelrc=.ci.bazelrc info  --remote_http_cache=http://$CIRRUS_HTTP_CACHE_HOST  release
   build_script:

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -17,18 +17,10 @@ jflex_deps()
 
 # pandoc used to build the documentatoin
 
-# TODO(regisd) Take upstream when they have accepted my PR to allow specifying output
-# https://github.com/ProdriveTechnologies/bazel-pandoc/pull/1
-#http_archive(
-#    name = "bazel_pandoc",
-#    strip_prefix = "bazel-pandoc-0.1",
-#    url = "https://github.com/ProdriveTechnologies/bazel-pandoc/archive/v0.1.tar.gz",
-#)
 http_archive(
     name = "bazel_pandoc",
-    sha256 = "0dd9d0d44658d46a96c36caba25f7ce9f119a6883c3219f61b76c11cfdc83c8f",
-    strip_prefix = "bazel_pandoc-0.1.1",
-    url = "https://github.com/regisd/bazel_pandoc/archive/v0.1.1.tar.gz",
+    strip_prefix = "bazel-pandoc-0.2",
+    url = "https://github.com/ProdriveTechnologies/bazel-pandoc/archive/v0.2.tar.gz",
 )
 
 load("@bazel_pandoc//:repositories.bzl", "pandoc_repositories")
@@ -39,9 +31,9 @@ pandoc_repositories()
 
 http_archive(
     name = "bazel_latex",
-    sha256 = "ecab535bb50699817cea662014432b4398edd7318ee6a6f64399a3287010961c",
-    strip_prefix = "bazel-latex-0.9",
-    url = "https://github.com/ProdriveTechnologies/bazel-latex/archive/v0.9.tar.gz",
+    sha256 = "b4dd9ae76c570b328be30cdc5ea7045a61ecd55e4e6e2e433fb3bb959be2a44b",
+    strip_prefix = "bazel-latex-0.16",
+    url = "https://github.com/ProdriveTechnologies/bazel-latex/archive/v0.16.tar.gz",
 )
 
 load("@bazel_latex//:repositories.bzl", "latex_repositories")

--- a/docs/BUILD
+++ b/docs/BUILD
@@ -62,7 +62,7 @@ latex_document(
         "@bazel_latex//packages:graphicx",
         "@bazel_latex//packages:hyperref",
         "@bazel_latex//packages:microtype",
-        # "@bazel_latex//packages:upquote",
+        "@bazel_latex//packages:upquote",
     ] + TEX_SRCS,
     main = "manual_full.tex",
 )

--- a/docs/BUILD
+++ b/docs/BUILD
@@ -23,6 +23,8 @@ MD_SRCS = ["md/head.md"] + ["md/" + src + ".md" for src in DOC_SECTIONS]
 
 TEX_SRCS = [":" + section + "_tex" for section in DOC_SECTIONS]
 
+# TODO(regisd) Add `output` attribute
+# https://github.com/ProdriveTechnologies/bazel-pandoc/pull/1
 pandoc(
     name = "html",
     src = ":manual_md",
@@ -34,7 +36,6 @@ pandoc(
     # TODO: Add ["--filter", "pandoc-citeproc"] when #2 is fixed
     # https://github.com/ProdriveTechnologies/bazel-pandoc/issues/2
     options = [],
-    output = "manual.html",
     to_format = "html",
 )
 
@@ -80,6 +81,6 @@ genrule(
     name = "latex_content",
     srcs = TEX_SRCS,
     outs = ["_content.tex"],
-    cmd = "echo '" + ("\n".join(["\\input{docs/" + section + "}" for section in DOC_SECTIONS])) + "' > $@",
+    cmd = "echo '" + ("\n".join(["\\input{docs/" + section + "_tex}" for section in DOC_SECTIONS])) + "' > $@",
     output_to_bindir = True,  # that's where pdf_latex looks into
 )

--- a/docs/docs.bzl
+++ b/docs/docs.bzl
@@ -32,7 +32,6 @@ def jflex_doc_tex(name, src = None):
         name = name + "_tex",
         src = ":" + name + "_md",
         from_format = "markdown",
-        output = name + ".tex",  # If changed, then change \include{} in manual.tex
         to_format = "latex",
         options = ["--biblatex"],
     )

--- a/docs/manual_full.tex
+++ b/docs/manual_full.tex
@@ -6,8 +6,7 @@
 \usepackage{geometry}
 \usepackage{graphicx}
 \usepackage{microtype}
-% upquote depends on https://github.com/ProdriveTechnologies/bazel-latex/pull/4
-% \usepackage{upquote}
+\usepackage{upquote}
 \usepackage{color}
 \definecolor{lcol}{rgb}{0.2470,0.3176,0.7098}
 \usepackage[
@@ -35,8 +34,6 @@
 % pandoc now uses \tightlist
 \providecommand{\tightlist}{%
   \setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}}
-
-\newcommand{\textquotesingle}{'}
 
 \newcommand{\autocite}[1]{\cite{#1}}
 \newcommand{\textcite}[1]{\cite{#1}}


### PR DESCRIPTION
* Update bazel-latex to 0.16
* Update bazel-pandoc to 0.2
* Fix Invalid toolchain
> external/bazel_pandoc/BUILD.bazel:6:1: in toolchain_type attribute of toolchain rule @bazel_pandoc//:pandoc_toolchain_linux: rule '@bazel_pandoc//:pandoc_toolchain_type' does not exist. Since this rule was created by the macro 'pandoc_toolchain', the error might have been caused by the macro implementation in /usr/local/google/home/regisd/.cache/bazel/_bazel_regisd/d1298cc00c93bfbf087444414b619b42/external/bazel_pandoc/toolchain.bzl:30:26
* Use package upquote instead of redefining \textquotesingle (now that it exists in bazel-latex)
* Remove output attribute unknown to bazel-pandoc (because it was only in my fork)
