### PR TITLE
Fix Travis build

### DIFF
--- a/scripts/compile-aggregated-java-sources.sh
+++ b/scripts/compile-aggregated-java-sources.sh
@@ -11,6 +11,7 @@ mvnget() {
   ls lib/$jarfile
   if [ -f lib/$jarfile ]; then
     echo "Using cached $jarfile"
+    CP="$CP:lib/$jarfile"
     return 0
   fi
   wget $REPO/$dep -P lib


### PR DESCRIPTION
aggregated-java-sources fails to build with

> Using cached ant-1.7.0.jar
> lib/auto-value-annotations-1.6.2.jar
> Using cached auto-value-annotations-1.6.2.jar
> ./java/jflex/base/IntPair.java:12: error: package com.google.auto.value does not exist
> import com.google.auto.value.AutoValue;
>                             ^
> ./java/jflex/base/IntPair.java:22: error: cannot find symbol
> @AutoValue