### PR TITLE
Refactor unicode Maven plugin

### DIFF
--- a/java/jflex/ucd/BUILD
+++ b/java/jflex/ucd/BUILD
@@ -1,0 +1,5 @@
+java_library(
+    name = "ucd",
+    srcs = glob(["*.java"]),
+    visibility = ["//java/jflex:__subpackages__"],
+)

--- a/java/jflex/ucd/README.md
+++ b/java/jflex/ucd/README.md
@@ -1,0 +1,8 @@
+# Unicode data definition
+
+This package contains an API and data objects for definition a Unicode spec.
+
+It is used by both:
+
+- The bazel program //java/jflex/ucd_generator
+- The Maven plugin jflex-unicode-maven-plugin

--- a/java/jflex/ucd/UcdVersion.java
+++ b/java/jflex/ucd/UcdVersion.java
@@ -1,0 +1,5 @@
+package jflex.ucd;
+
+public interface UcdVersion {
+
+}

--- a/java/jflex/ucd/UcdVersion.java
+++ b/java/jflex/ucd/UcdVersion.java
@@ -14,6 +14,12 @@ public interface UcdVersion {
 
   void addCompatibilityProperties();
 
-  /** Unicode versionMajorMinor in the form {@code X.Y}. */
+  /** Returns the Unicode versionMajorMinor in the form {@code X.Y}. */
   String getMajorMinorVersion();
+
+  /** Returns the Unicode versionMajorMinor in the form {@code X.Y.Z}. */
+  String getMajorMinorPatchVersion();
+
+  /** Returns a class name for the unicode version. */
+  String getUnicodeClassName();
 }

--- a/java/jflex/ucd/UcdVersion.java
+++ b/java/jflex/ucd/UcdVersion.java
@@ -1,5 +1,19 @@
 package jflex.ucd;
 
-public interface UcdVersion {
+import java.io.IOException;
 
+public interface UcdVersion {
+  /**
+   * Fetches and parses the data files defined for this Unicode versionMajorMinor.
+   *
+   * @throws IOException If there is a problem fetching or parsing any of this versionMajorMinor's
+   *     data files.
+   */
+  // TODO(regisd) Split the fetch and the parse parts. The Bazel impl doesn't fetch.
+  void fetchAndParseDataFiles() throws IOException;
+
+  void addCompatibilityProperties();
+
+  /** Unicode versionMajorMinor in the form {@code X.Y}. */
+  String getMajorMinorVersion();
 }

--- a/java/jflex/ucd/pom.xml
+++ b/java/jflex/ucd/pom.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>de.jflex</groupId>
+    <artifactId>jflex-parent</artifactId>
+    <version>1.8.0-SNAPSHOT</version>
+    <relativePath>../../../pom.xml</relativePath>
+  </parent>
+  <artifactId>ucd</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <name>ucd</name>
+
+  <build>
+    <sourceDirectory>.</sourceDirectory>
+  </build>
+
+  <dependencies>
+
+  </dependencies>
+
+</project>

--- a/java/jflex/ucd_generator/BUILD
+++ b/java/jflex/ucd_generator/BUILD
@@ -4,16 +4,19 @@ SRCS_MAIN = ["Main.java"]
 
 java_library(
     name = "ucd_generator",
-    srcs = ["UcdGenerator.java", "UcdGeneratorParams.java"],
+    srcs = [
+        "UcdGenerator.java",
+        "UcdGeneratorParams.java",
+    ],
     deps = [
         "//java/jflex/testing/javac",
-        "//java/jflex/ucd_generator/ucd",
         "//java/jflex/ucd_generator/emitter/unicode_properties",
         "//java/jflex/ucd_generator/emitter/unicode_version",
+        "//java/jflex/ucd_generator/ucd",
         "//java/jflex/velocity",
+        "//third_party/com/google/auto_value",
         "//third_party/com/google/guava",
         "//third_party/org/apache/velocity",
-        "//third_party/com/google/auto_value",
     ],
 )
 

--- a/java/jflex/ucd_generator/UcdGenerator.java
+++ b/java/jflex/ucd_generator/UcdGenerator.java
@@ -67,7 +67,7 @@ public class UcdGenerator {
       throws IOException, ParseException {
     for (Version version : ucdVersions.versionSet()) {
       UcdVersion ucdVersion = ucdVersions.get(version);
-      String unicodeClassName = version.unicodeClassName();
+      String unicodeClassName = ucdVersion.getUnicodeClassName();
       System.out.println(String.format("Emitting %s", unicodeClassName));
       File outputFile = new File(outputDir, unicodeClassName + ".java");
       UnicodeVersionEmitter emitter = new UnicodeVersionEmitter(PACKAGE_JFLEX_UNICODE, ucdVersion);

--- a/java/jflex/ucd_generator/emitter/unicode_version/UnicodeVersionEmitter.java
+++ b/java/jflex/ucd_generator/emitter/unicode_version/UnicodeVersionEmitter.java
@@ -35,7 +35,7 @@ public class UnicodeVersionEmitter extends UcdEmitter {
   private UnicodeVersionVars createUnicodeVersionVars() {
     UnicodeVersionVars unicodeVersionVars = new UnicodeVersionVars();
     unicodeVersionVars.packageName = getTargetPackage();
-    unicodeVersionVars.className = ucdVersion.getVersion().unicodeClassName();
+    unicodeVersionVars.className = ucdVersion.getUnicodeClassName();
     return unicodeVersionVars;
   }
 }

--- a/java/jflex/ucd_generator/ucd/BUILD
+++ b/java/jflex/ucd_generator/ucd/BUILD
@@ -1,11 +1,12 @@
 java_library(
     name = "ucd",
     srcs = glob(["*.java"]),
-    deps = [
-        "//third_party/com/google/guava",
-    ],
     visibility = [
         "//java/jflex/ucd_generator:__subpackages__",
         "//javatests/jflex/ucd_generator:__subpackages__",
+    ],
+    deps = [
+        "//java/jflex/ucd",
+        "//third_party/com/google/guava",
     ],
 )

--- a/java/jflex/ucd_generator/ucd/UcdVersion.java
+++ b/java/jflex/ucd_generator/ucd/UcdVersion.java
@@ -34,11 +34,15 @@ public class UcdVersion implements jflex.ucd.UcdVersion {
 
   private final Version version;
   private final String versionMajorMinor;
+  private final String versionMajorMinorPatch;
+  private final String unicodeClassName;
   final ImmutableMap<jflex.ucd_generator.ucd.UcdFileType, File> files;
 
   UcdVersion(Version version, ImmutableMap<UcdFileType, File> files) {
     this.version = version;
     this.versionMajorMinor = version.toMajorMinorString();
+    this.versionMajorMinorPatch = version.toMajorMinorPatchString();
+    this.unicodeClassName = "Unicode_" + versionMajorMinor.replace(',', '_');
     this.files = files;
   }
 
@@ -64,7 +68,17 @@ public class UcdVersion implements jflex.ucd.UcdVersion {
 
   @Override
   public String getMajorMinorVersion() {
-    return null;
+    return versionMajorMinor;
+  }
+
+  @Override
+  public String getMajorMinorPatchVersion() {
+    return versionMajorMinorPatch;
+  }
+
+  @Override
+  public String getUnicodeClassName() {
+    return "Unicode_" + versionMajorMinor.replace('.', '_');
   }
 
   public static class Builder {

--- a/java/jflex/ucd_generator/ucd/UcdVersion.java
+++ b/java/jflex/ucd_generator/ucd/UcdVersion.java
@@ -27,15 +27,18 @@ package jflex.ucd_generator.ucd;
 
 import com.google.common.collect.ImmutableMap;
 import java.io.File;
+import java.io.IOException;
 
-/** Describes a single Unicode version. */
+/** Describes a single Unicode versionMajorMinor. */
 public class UcdVersion implements jflex.ucd.UcdVersion {
 
-  public final String version;
+  private final Version version;
+  private final String versionMajorMinor;
   final ImmutableMap<jflex.ucd_generator.ucd.UcdFileType, File> files;
 
-  UcdVersion(String version, ImmutableMap<UcdFileType, File> files) {
+  UcdVersion(Version version, ImmutableMap<UcdFileType, File> files) {
     this.version = version;
+    this.versionMajorMinor = version.toMajorMinorString();
     this.files = files;
   }
 
@@ -44,15 +47,32 @@ public class UcdVersion implements jflex.ucd.UcdVersion {
   }
 
   public Version getVersion() {
-    return new Version(version);
+    return new Version(versionMajorMinor);
+  }
+
+  @Override
+  public void fetchAndParseDataFiles() throws IOException {
+    // TODO(regisd) Implement the parser
+    throw new UnsupportedOperationException("TODO");
+  }
+
+  @Override
+  public void addCompatibilityProperties() {
+    // TODO(regisd) Implement
+    throw new UnsupportedOperationException("TODO");
+  }
+
+  @Override
+  public String getMajorMinorVersion() {
+    return null;
   }
 
   public static class Builder {
     private ImmutableMap.Builder<jflex.ucd_generator.ucd.UcdFileType, File> files =
         ImmutableMap.builder();
-    private String version;
+    private Version version;
 
-    public Builder withVersion(String version) {
+    public Builder withVersion(Version version) {
       this.version = version;
       return this;
     }

--- a/java/jflex/ucd_generator/ucd/UcdVersion.java
+++ b/java/jflex/ucd_generator/ucd/UcdVersion.java
@@ -29,12 +29,12 @@ import com.google.common.collect.ImmutableMap;
 import java.io.File;
 
 /** Describes a single Unicode version. */
-public class UcdVersion {
+public class UcdVersion implements jflex.ucd.UcdVersion {
 
   public final String version;
   final ImmutableMap<jflex.ucd_generator.ucd.UcdFileType, File> files;
 
-  UcdVersion(String version, ImmutableMap<jflex.ucd_generator.ucd.UcdFileType, File> files) {
+  UcdVersion(String version, ImmutableMap<UcdFileType, File> files) {
     this.version = version;
     this.files = files;
   }

--- a/java/jflex/ucd_generator/ucd/UcdVersions.java
+++ b/java/jflex/ucd_generator/ucd/UcdVersions.java
@@ -37,7 +37,7 @@ import java.util.List;
 /** A set of {@link UcdVersion}s. */
 public class UcdVersions {
 
-  // version –> Map<UcdFileType, File>
+  // versionMajorMinor –> Map<UcdFileType, File>
   private final ImmutableSortedMap<Version, UcdVersion> versions;
 
   private UcdVersions(ImmutableSortedMap<Version, UcdVersion> versions) {
@@ -71,11 +71,11 @@ public class UcdVersions {
     return "Unicode_" + Joiner.on('_').join(v.subList(0, min(2, v.size())));
   }
 
-  /** Expands the version {@code x.y.z} into {@code x}, {@code x.y}, {@code x.y.z}. */
+  /** Expands the versionMajorMinor {@code x.y.z} into {@code x}, {@code x.y}, {@code x.y.z}. */
   @SuppressWarnings("unused") // Used in .vm
   public static ImmutableList<String> expandVersion(Version version) {
     ImmutableList.Builder<String> expandedVersions = ImmutableList.builder();
-    // Add the major version x if it is a x.0.z version
+    // Add the major versionMajorMinor x if it is a x.0.z versionMajorMinor
     if (version.minor == -1 || (version.minor == 0 && version.patch != -1)) {
       expandedVersions.add(String.valueOf(version.major));
     }
@@ -118,7 +118,8 @@ public class UcdVersions {
     }
 
     public Builder put(String version, UcdVersion.Builder ucdFiles) {
-      return put(new Version(version), ucdFiles.withVersion(version));
+      Version v = new Version(version);
+      return put(v, ucdFiles.withVersion(v));
     }
 
     public UcdVersions build() {

--- a/java/jflex/ucd_generator/ucd/Version.java
+++ b/java/jflex/ucd_generator/ucd/Version.java
@@ -44,7 +44,15 @@ public class Version implements Comparable<Version> {
 
   @Override
   public String toString() {
+    return toMajorMinorPatchString();
+  }
+
+  private String toMajorMinorPatchString() {
     return makeString('.', true);
+  }
+
+  public String toMajorMinorString() {
+    return makeString('.', false);
   }
 
   public String unicodeClassName() {

--- a/java/jflex/ucd_generator/ucd/Version.java
+++ b/java/jflex/ucd_generator/ucd/Version.java
@@ -47,16 +47,12 @@ public class Version implements Comparable<Version> {
     return toMajorMinorPatchString();
   }
 
-  private String toMajorMinorPatchString() {
+  public String toMajorMinorPatchString() {
     return makeString('.', true);
   }
 
   public String toMajorMinorString() {
     return makeString('.', false);
-  }
-
-  public String unicodeClassName() {
-    return String.format("Unicode_%s", makeString('_', false));
   }
 
   private String makeString(char sep, boolean includePatch) {

--- a/javatests/jflex/ucd_generator/emitter/unicode_version/UnicodeVersionEmitterTest.java
+++ b/javatests/jflex/ucd_generator/emitter/unicode_version/UnicodeVersionEmitterTest.java
@@ -8,6 +8,7 @@ import java.nio.charset.StandardCharsets;
 import jflex.testing.diff.DiffOutputStream;
 import jflex.ucd_generator.ucd.UcdFileType;
 import jflex.ucd_generator.ucd.UcdVersion;
+import jflex.ucd_generator.ucd.Version;
 import org.junit.Test;
 
 /** Test for {@link UnicodeVersionEmitter}. */
@@ -23,7 +24,7 @@ public class UnicodeVersionEmitterTest {
     // fake ucd version 0.1
     UcdVersion ucd0_1 =
         UcdVersion.builder()
-            .withVersion("0.1")
+            .withVersion(new Version("0.1"))
             .putFile(UcdFileType.UnicodeData, new File("FakeUnicodeData.txt"))
             .build();
 

--- a/jflex-unicode-maven-plugin/pom.xml
+++ b/jflex-unicode-maven-plugin/pom.xml
@@ -66,5 +66,10 @@
       <groupId>org.apache.maven.plugin-tools</groupId>
       <artifactId>maven-plugin-annotations</artifactId>
     </dependency>
+    <dependency>
+      <groupId>de.jflex</groupId>
+      <artifactId>ucd</artifactId>
+      <version>1.0-SNAPSHOT</version>
+    </dependency>
   </dependencies>
 </project>

--- a/jflex-unicode-maven-plugin/src/main/java/jflex/maven/plugin/unicode/JFlexUnicodeMojo.java
+++ b/jflex-unicode-maven-plugin/src/main/java/jflex/maven/plugin/unicode/JFlexUnicodeMojo.java
@@ -22,6 +22,7 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import jflex.ucd.UcdVersion;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
@@ -224,14 +225,14 @@ public class JFlexUnicodeMojo extends AbstractMojo {
     if (null != dataFiles.get(DataFileType.UNICODE_DATA)) {
       // If UnicodeData(-X.X.X).txt was found, then this version of Unicode
       // is not a beta version, so we can proceed to fetch, parse, and emit.
-      UnicodeVersion unicodeVersion = new UnicodeVersion(version, dataFiles);
-      unicodeVersion.fetchAndParseDataFiles(getLog());
+      UcdVersion unicodeVersion = new UnicodeVersion(version, dataFiles, getLog());
+      unicodeVersion.fetchAndParseDataFiles();
       unicodeVersion.addCompatibilityProperties();
-      unicodeVersions.put(unicodeVersion.majorMinorVersion, unicodeVersion);
+      unicodeVersions.put(unicodeVersion.getMajorMinorVersion(), (UnicodeVersion) unicodeVersion);
       getLog()
           .info(
               "Completed downloading and parsing Unicode "
-                  + unicodeVersion.majorMinorVersion
+                  + unicodeVersion.getMajorMinorVersion()
                   + " data.\n");
     }
   }

--- a/jflex-unicode-maven-plugin/src/main/java/jflex/maven/plugin/unicode/UnicodeVersion.java
+++ b/jflex-unicode-maven-plugin/src/main/java/jflex/maven/plugin/unicode/UnicodeVersion.java
@@ -30,6 +30,7 @@ import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import jflex.ucd.UcdVersion;
 import org.apache.maven.plugin.logging.Log;
 
 /**
@@ -56,7 +57,7 @@ import org.apache.maven.plugin.logging.Log;
  * UnicodeProperties.java) the set of Property Values supported by this version of Unicode, as well
  * as the corresponding code point interval sets for each member of the Property Value set.
  */
-class UnicodeVersion {
+class UnicodeVersion implements UcdVersion {
 
   /** Pattern for the full Unicode version */
   private static final Pattern FULL_VERSION_PATTERN = Pattern.compile("((\\d+)\\.(\\d+))\\.\\d+");

--- a/jflex-unicode-maven-plugin/src/main/java/jflex/maven/plugin/unicode/UnicodeVersion.java
+++ b/jflex-unicode-maven-plugin/src/main/java/jflex/maven/plugin/unicode/UnicodeVersion.java
@@ -194,7 +194,7 @@ class UnicodeVersion implements UcdVersion {
   }
 
   public void emitToDir(File outputDir) throws IOException {
-    String generatedClassName = getGeneratedClassName();
+    String generatedClassName = getUnicodeClassName();
     PrintWriter writer =
         new PrintWriter(new File(outputDir, generatedClassName + ".java"), "UTF-8");
     writer.append("package jflex.core.unicode.data;\n\n");
@@ -683,12 +683,9 @@ class UnicodeVersion implements UcdVersion {
     }
   }
 
-  /**
-   * Returns an class name for the unicode version, suffixed the Unicode major.minor version
-   *
-   * @return "Unicode_X_Y", where X = major version, and Y = minor version.
-   */
-  String getGeneratedClassName() {
+  /** @return "Unicode_X_Y", where X = major version, and Y = minor version. */
+  @Override
+  public String getUnicodeClassName() {
     return String.format("Unicode_%s", majorMinorVersion.replace(".", "_"));
   }
 
@@ -915,5 +912,10 @@ class UnicodeVersion implements UcdVersion {
   @Override
   public String getMajorMinorVersion() {
     return majorMinorVersion;
+  }
+
+  @Override
+  public String getMajorMinorPatchVersion() {
+    return majorMinorUpdateVersion;
   }
 }

--- a/jflex-unicode-maven-plugin/src/main/java/jflex/maven/plugin/unicode/UnicodeVersion.java
+++ b/jflex-unicode-maven-plugin/src/main/java/jflex/maven/plugin/unicode/UnicodeVersion.java
@@ -93,6 +93,9 @@ class UnicodeVersion implements UcdVersion {
   private static final Pattern SURROGATE_PATTERN =
       Pattern.compile("^cs$|surrogate", Pattern.CASE_INSENSITIVE);
 
+  /** Maven logger. */
+  private final Log log;
+
   /** Unicode version X.X.X */
   String majorMinorUpdateVersion;
 
@@ -145,20 +148,16 @@ class UnicodeVersion implements UcdVersion {
    *
    * @param version The Unicode version, either in form "X.X.X" or "X.X".
    * @param dataFiles Set of unicode data file types and corresponding URLs to be fetched and
-   *     parsed.
+   * @param log Maven logger.
    */
-  UnicodeVersion(String version, EnumMap<DataFileType, URL> dataFiles) {
+  UnicodeVersion(String version, EnumMap<DataFileType, URL> dataFiles, Log log) {
     this.dataFiles = dataFiles;
     setVersions(version, dataFiles.get(DataFileType.UNICODE_DATA));
+    this.log = log;
   }
 
-  /**
-   * Fetches and parses the data files defined for this Unicode version.
-   *
-   * @param log Where to put info about which files have been fetched and parsed
-   * @throws IOException If there is a problem fetching or parsing any of this version's data files.
-   */
-  public void fetchAndParseDataFiles(Log log) throws IOException {
+  @Override
+  public void fetchAndParseDataFiles() throws IOException {
     // Use the enum ordering to process in the correct order
     for (EnumMap.Entry<DataFileType, URL> entry : dataFiles.entrySet()) {
       DataFileType fileType = entry.getKey();
@@ -911,5 +910,10 @@ class UnicodeVersion implements UcdVersion {
     printSet.sub(propertyValueIntervals.get("cc"));
     propertyValueIntervals.put("print", printSet);
     usedBinaryProperties.add("print");
+  }
+
+  @Override
+  public String getMajorMinorVersion() {
+    return majorMinorVersion;
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,7 @@
   <modules>
     <module>cup</module>
     <module>cup-maven-plugin</module>
+    <module>java/jflex/ucd</module>
     <module>jflex-unicode-maven-plugin</module>
     <module>jflex</module>
     <module>jflex-maven-plugin</module>


### PR DESCRIPTION
Extract a common interface that will be used by both the Maven-based jflex-unicode-maven-plugin and the bazel-based ucd_generator.

The goal is to reuse the Unicode flex scanners as much as possible.
