### PR TITLE
Fix the build

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,3 +1,9 @@
+# This incompatible change was introduced in Bazel 0.26
+# https://github.com/bazelbuild/bazel/issues/5817
+# bazel_pandoc needs to update 
+# https://github.com/ProdriveTechnologies/bazel-pandoc/issues/6
+build --incompatible_depset_union=false
+
 test --test_output=errors
 
 # http://errorprone.info/bugpatterns

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ jflex/build
 *.ipr
 *.iws
 .idea
+.ijwb
 
 # Eclipse project
 .project

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ git:
 language: java
 
 jdk:
-- oraclejdk9
+- openjdk10
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ git:
 language: java
 
 jdk:
-- openjdk10
+- openjdk9
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,23 +38,6 @@ matrix:
   - name: "👴 Examples (mvn, ant, make) — JDK8"
     script: scripts/test-examples.sh
     jdk: openjdk8
-  - name: "📄 Documentation"
-    language: generic
-    install: true
-    addons:
-      apt:
-        packages:
-        # pandoc used for building the doc
-        - pandoc
-        - pandoc-citeproc
-        # texlive used for PDF output
-        - texlive
-        # texlive-latex-extra provides extra styles such as a4wide and upquote.sty
-        - texlive-latex-extra
-        # lmodern.sty
-        - lmodern
-    script:
-    - cd docs; make; cd ..
 
 # Empty the previously built artifacts
 # They cannot be deleted in the before_cache phase,

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ git:
 language: java
 
 jdk:
-- openjdk9
+- oraclejdk9
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,9 +35,9 @@ matrix:
     - scripts/test-regression.sh
   - name: "😎 Examples (mvn, ant, make)"
     script: scripts/test-examples.sh
-  - name: "👴 Examples (mvn, ant, make) — JDK7"
+  - name: "👴 Examples (mvn, ant, make) — JDK8"
     script: scripts/test-examples.sh
-    jdk: openjdk7
+    jdk: openjdk8
   - name: "📄 Documentation"
     language: generic
     install: true
@@ -111,4 +111,3 @@ deploy:
     condition:
     - $PUBLISH_SOURCES
   script: scripts/deploy-aggregated-sources.sh
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ git:
 language: java
 
 jdk:
-- openjdk9
+- openjdk11
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ git:
 language: java
 
 jdk:
-- openjdk9
+- openjdk10
 
 matrix:
   include:

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -8,7 +8,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 git_repository(
     name = "jflex_rules",
     remote = "https://github.com/jflex-de/bazel_rules.git",
-    tag = "v3",
+    tag = "v4",
 )
 
 load("@jflex_rules//jflex:deps.bzl", "jflex_deps")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -28,12 +28,20 @@ load("@bazel_pandoc//:repositories.bzl", "pandoc_repositories")
 pandoc_repositories()
 
 # latex rule to build PDF from tex files
-
-http_archive(
+#
+#http_archive(
+#    name = "bazel_latex",
+#    sha256 = "b4dd9ae76c570b328be30cdc5ea7045a61ecd55e4e6e2e433fb3bb959be2a44b",
+#    strip_prefix = "bazel-latex-0.16",
+#    url = "https://github.com/ProdriveTechnologies/bazel-latex/archive/v0.16.tar.gz",
+#)
+#
+# This is a proposed fix for `OSError: [Errno 13] Permission denied: run_lualatex.py`
+# https://github.com/ProdriveTechnologies/bazel-latex/issues/23
+git_repository(
     name = "bazel_latex",
-    sha256 = "b4dd9ae76c570b328be30cdc5ea7045a61ecd55e4e6e2e433fb3bb959be2a44b",
-    strip_prefix = "bazel-latex-0.16",
-    url = "https://github.com/ProdriveTechnologies/bazel-latex/archive/v0.16.tar.gz",
+    commit = "1ba1fb087b8526cfe28c7c31471f412107ee6f09",
+    remote = "https://github.com/Selmaai/bazel-latex.git",
 )
 
 load("@bazel_latex//:repositories.bzl", "latex_repositories")

--- a/cup-maven-plugin/pom.xml
+++ b/cup-maven-plugin/pom.xml
@@ -77,16 +77,4 @@
     </dependency>
   </dependencies>
 
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/cup/pom.xml
+++ b/cup/pom.xml
@@ -74,7 +74,7 @@
       <plugins>
         <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.7.0</version>
+          <version>3.8.0</version>
         </plugin>
         <plugin>
           <artifactId>maven-deploy-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -290,7 +290,7 @@
         </plugin>
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.20.1</version>
+          <version>3.0.0-M3</version>
         </plugin>
       </plugins>
     </pluginManagement>
@@ -445,6 +445,9 @@
       <id>error-prone</id>
       <activation>
         <jdk>[1.9,)</jdk>
+        <property>
+          <name>DISABLED</name>
+        </property>
       </activation>
       <build>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -204,7 +204,7 @@
           <version>2.5.0</version>
         </plugin>
         <plugin>
-          <artifactId>maven-compiler-plugin</artifactId>
+          <artifactId>maven-`compiler-plugin</artifactId>
           <version>3.8.0</version>
         </plugin>
         <plugin>
@@ -300,8 +300,8 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>8</source>
+          <target>8</target>
         </configuration>
       </plugin>
       <plugin>
@@ -444,7 +444,7 @@
     <profile>
       <id>error-prone</id>
       <activation>
-        <jdk>[1.8,)</jdk>
+        <jdk>[1.9,)</jdk>
       </activation>
       <build>
         <plugins>
@@ -455,8 +455,7 @@
               <target>8</target>
               <compilerArgs>
                 <arg>-XDcompilePolicy=simple</arg>
-                <arg>-Xplugin:ErrorProne
-                     -Xep:FallThrough:WARN</arg>
+                <arg>-Xplugin:ErrorProne -Xep:FallThrough:WARN</arg>
               </compilerArgs>
               <annotationProcessorPaths>
                 <path>

--- a/pom.xml
+++ b/pom.xml
@@ -253,7 +253,7 @@
         </plugin>
         <plugin>
           <artifactId>maven-javadoc-plugin</artifactId>
-          <version>2.10.1</version>
+          <version>3.1.1</version>
         </plugin>
         <plugin>
           <artifactId>maven-jar-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -282,7 +282,7 @@
         </plugin>
         <plugin>
           <artifactId>maven-site-plugin</artifactId>
-          <version>3.6</version>
+          <version>3.8.2</version>
         </plugin>
         <plugin>
           <artifactId>maven-source-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -205,7 +205,7 @@
         </plugin>
         <plugin>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.7.0</version>
+          <version>3.8.0</version>
         </plugin>
         <plugin>
           <artifactId>maven-deploy-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -455,8 +455,8 @@
               <target>8</target>
               <compilerArgs>
                 <arg>-XDcompilePolicy=simple</arg>
-                <arg>-Xplugin:ErrorProne</arg>
-                <arg>-Xep:FallThrough:WARN</arg>
+                <arg>-Xplugin:ErrorProne
+                     -Xep:FallThrough:WARN</arg>
               </compilerArgs>
               <annotationProcessorPaths>
                 <path>

--- a/pom.xml
+++ b/pom.xml
@@ -254,6 +254,10 @@
         <plugin>
           <artifactId>maven-javadoc-plugin</artifactId>
           <version>3.1.1</version>
+          <configuration>
+            <!-- https://bugs.openjdk.java.net/browse/JDK-8212233 -->
+            <source>8</source>
+          </configuration>
         </plugin>
         <plugin>
           <artifactId>maven-jar-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -452,27 +452,21 @@
             <artifactId>maven-compiler-plugin</artifactId>
             <configuration>
               <compilerId>javac-with-errorprone</compilerId>
-              <forceJavacCompilerUse>true</forceJavacCompilerUse>
+              <source>8</source>
+              <target>8</target>
               <compilerArgs>
+                <arg>-XDcompilePolicy=simple</arg>
+                <arg>-Xplugin:ErrorProne</arg>
                 <arg>-Xep:FallThrough:WARN</arg>
               </compilerArgs>
-              <source>1.7</source>
-              <target>1.7</target>
+              <annotationProcessorPaths>
+                <path>
+                  <groupId>com.google.errorprone</groupId>
+                  <artifactId>error_prone_core</artifactId>
+                  <version>2.3.3</version>
+                </path>
+              </annotationProcessorPaths>
             </configuration>
-            <dependencies>
-              <dependency>
-                <groupId>org.codehaus.plexus</groupId>
-                <artifactId>plexus-compiler-javac-errorprone</artifactId>
-                <version>2.8</version>
-              </dependency>
-              <!-- override plexus-compiler-javac-errorprone's dependency on
-                   Error Prone with the latest version -->
-              <dependency>
-                <groupId>com.google.errorprone</groupId>
-                <artifactId>error_prone_core</artifactId>
-                <version>2.1.1</version>
-              </dependency>
-            </dependencies>
           </plugin>
         </plugins>
       </build>

--- a/pom.xml
+++ b/pom.xml
@@ -451,7 +451,6 @@
           <plugin>
             <artifactId>maven-compiler-plugin</artifactId>
             <configuration>
-              <compilerId>javac-with-errorprone</compilerId>
               <source>8</source>
               <target>8</target>
               <compilerArgs>

--- a/pom.xml
+++ b/pom.xml
@@ -204,7 +204,7 @@
           <version>2.5.0</version>
         </plugin>
         <plugin>
-          <artifactId>maven-`compiler-plugin</artifactId>
+          <artifactId>maven-compiler-plugin</artifactId>
           <version>3.8.0</version>
         </plugin>
         <plugin>

--- a/scripts/compile-aggregated-java-sources.sh
+++ b/scripts/compile-aggregated-java-sources.sh
@@ -20,6 +20,7 @@ mvnget() {
 
 mvnget org/apache/ant/ant/1.7.0/ant-1.7.0.jar
 mvnget com/google/auto/value/auto-value-annotations/1.6.2/auto-value-annotations-1.6.2.jar
+mvnget javax/annotation/javax.annotation-api/1.3.2/javax.annotation-api-1.3.2.jar
 
 CP=${CP##:}  # Remove leading ':'
 javac -cp "$CP" $(find . -name '*.java')

--- a/third_party/deps.bzl
+++ b/third_party/deps.bzl
@@ -33,20 +33,20 @@ def third_party_deps():
     native.maven_jar(
         name = "com_google_auto_value_auto_value",
         artifact = "com.google.auto.value:auto-value:jar:1.4.1",
-        repository = "http://jcenter.bintray.com/",
+        repository = "https://jcenter.bintray.com/",
     )
     native.maven_jar(
         name = "com_google_guava_guava",
         artifact = "com.google.guava:guava:jar:26.0-jre",
-        repository = "http://jcenter.bintray.com/",
+        repository = "https://jcenter.bintray.com/",
     )
     native.maven_jar(
         name = "com_google_truth_truth",
         artifact = "com.google.truth:truth:0.36",
-        repository = "http://jcenter.bintray.com/",
+        repository = "https://jcenter.bintray.com/",
     )
     native.maven_jar(
         name = "junit_junit",
         artifact = "junit:junit:jar:4.12",
-        repository = "http://jcenter.bintray.com/",
+        repository = "https://jcenter.bintray.com/",
     )


### PR DESCRIPTION
* Fix #570. Build broken on Cirrus by upgrade to Bazel v1.0
  * The `single_file` attribute has been replaced by `allow_single_file`.
    Use **bazel_rules** v4 which fixed this. https://github.com/jflex-de/bazel_rules/pull/13
  * add `--incompatible_depset_union=false`
    bazel_pandoc https://github.com/ProdriveTechnologies/bazel-pandoc/issues/6 needs to update for incompatible_depset_union https://github.com/bazelbuild/bazel/issues/5817
  * Use ProdriveTechnologies/bazel-latex#26 because `run_lualatex.py` is not executable
  * In deps, use `https` rather than `http`
* Fix build broken on Travis due to upgrade to Xenial
  * Use openjdk11 because whatever I ask for, that's what I get.
  * Upgrade maven-compiler-plugin to 3.8.0 to fix _class file has wrong version 55.0, should be 53.0_
  * Fix maven-compiler-plugin config for ErrorProne
  * Fix config of maven-javadoc-plugin for newer JDK. https://bugs.openjdk.java.net/browse/JDK-8212233
  * In aggregated sources, update to JDK8 because Xenial doesn't support JDK7 anymore.
    Add manual dep on **javax-annotations.jar** because because JDK8 doesn't provide it anymore.
  * Remove the task that builds the docs because `\tightlist` is not known. #571 