### PR TITLE
Use trusty for aggregated-java-sources

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,13 @@
-script:
-- ./compile.sh
-- cd java; java jflex.Main --version; cd ..
+dist: trusty
 
 language: java
 
 jdk:
 - oraclejdk8
+
+script:
+- ./compile.sh
+- cd java; java jflex.Main --version; cd ..
 
 cache:
   directories:


### PR DESCRIPTION
Fix #573

Travis has changed the default VM to Xenial which cannot install java8.