### PR TITLE
Pin down bazel version 1.1.0

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -5,7 +5,7 @@
 build_task:
   name: Bazel build and test
   container:
-    image: l.gcr.io/google/bazel:latest
+    image: l.gcr.io/google/bazel:1.1.0
   bazel_version_script:
   - bazel --bazelrc=.ci.bazelrc info  --remote_http_cache=http://$CIRRUS_HTTP_CACHE_HOST  release
   build_script:


### PR DESCRIPTION
no-op, latest is 1.1.0, but this aligns with a CI best practice
> It is best practice to lock down aspects of your build container by specifying an additional tag to pin down the image in your configuration.
(from https://circleci.com/docs/2.0/circleci-images/#best-practices)