### PR TITLE
Introduce class ErrorMessages.ErrorMessage

### DIFF
--- a/jflex/src/main/cup/LexParse.cup
+++ b/jflex/src/main/cup/LexParse.cup
@@ -34,29 +34,29 @@ action code {:
   EOFActions  eofActions  = new EOFActions();
   Map<Integer,IntCharSet> preclassCache = new HashMap<Integer,IntCharSet>();
 
-  void fatalError(ErrorMessages message, int line, int col) {
+  void fatalError(ErrorMessages.ErrorMessage message, int line, int col) {
     syntaxError(message, line, col);
     throw new GeneratorException();
   }
 
-  void fatalError(ErrorMessages message) {
+  void fatalError(ErrorMessages.ErrorMessage message) {
     fatalError(message, scanner.currentLine(), -1);
     throw new GeneratorException();
   }
 
-  void syntaxError(ErrorMessages message) {
+  void syntaxError(ErrorMessages.ErrorMessage message) {
     Out.error(scanner.file, message, scanner.currentLine(), -1);
   }
   
-  void syntaxError(ErrorMessages message, int line) {
+  void syntaxError(ErrorMessages.ErrorMessage message, int line) {
     Out.error(scanner.file, message, line, -1);
   }
 
-  void syntaxError(ErrorMessages message, int line, int col) {
+  void syntaxError(ErrorMessages.ErrorMessage message, int line, int col) {
     Out.error(scanner.file, message, line, col);
   }
 
-  void warning(ErrorMessages message, int line, int col) {
+  void warning(ErrorMessages.ErrorMessage message, int line, int col) {
     Out.warning(scanner.file, message, line, col);
   }
 

--- a/jflex/src/main/java/jflex/core/Out.java
+++ b/jflex/src/main/java/jflex/core/Out.java
@@ -74,9 +74,9 @@ public final class Out {
    * @param message the message to be printed
    * @param time elapsed time
    */
-  public static void time(jflex.l10n.ErrorMessages message, Timer time) {
+  public static void time(ErrorMessages.ErrorMessage message, Timer time) {
     if (Options.time) {
-      String msg = jflex.l10n.ErrorMessages.get(message, time.toString());
+      String msg = ErrorMessages.get(message, time.toString());
       out.println(msg);
     }
   }
@@ -107,9 +107,9 @@ public final class Out {
    * @param message the message to be printed
    * @param data data to be inserted into the message
    */
-  public static void println(jflex.l10n.ErrorMessages message, String data) {
+  public static void println(ErrorMessages.ErrorMessage message, String data) {
     if (Options.verbose) {
-      out.println(jflex.l10n.ErrorMessages.get(message, data));
+      out.println(ErrorMessages.get(message, data));
     }
   }
 
@@ -119,9 +119,9 @@ public final class Out {
    * @param message the message to be printed
    * @param data data to be inserted into the message
    */
-  public static void println(jflex.l10n.ErrorMessages message, int data) {
+  public static void println(ErrorMessages.ErrorMessage message, int data) {
     if (Options.verbose) {
-      out.println(jflex.l10n.ErrorMessages.get(message, data));
+      out.println(ErrorMessages.get(message, data));
     }
   }
 
@@ -154,8 +154,7 @@ public final class Out {
    * All parts of JFlex, that want to provide dump information should use this method for their
    * output.
    *
-   * @message the message to be printed
-   * @param message a {@link java.lang.String} object.
+   * @param message the message to be printed
    */
   public static void dump(String message) {
     if (Options.dump) {
@@ -166,7 +165,7 @@ public final class Out {
   /**
    * All parts of JFlex, that want to report error messages should use this method for their output.
    *
-   * @message the message to be printed
+   * @param message the message to be printed
    */
   private static void err(String message) {
     out.println(message);
@@ -212,9 +211,9 @@ public final class Out {
    * print a warning message without line information
    *
    * @param message code of the warning message
-   * @see jflex.l10n.ErrorMessages
+   * @see ErrorMessages
    */
-  public static void warning(jflex.l10n.ErrorMessages message) {
+  public static void warning(ErrorMessages.ErrorMessage message) {
     warning(message, 0);
   }
 
@@ -223,15 +222,15 @@ public final class Out {
    *
    * @param message code of the warning message
    * @param line the line information
-   * @see jflex.l10n.ErrorMessages
+   * @see ErrorMessages
    */
-  public static void warning(jflex.l10n.ErrorMessages message, int line) {
+  public static void warning(ErrorMessages.ErrorMessage message, int line) {
     warnings++;
 
     String msg = NL + "Warning";
     if (line > 0) msg = msg + " in line " + (line + 1);
 
-    err(msg + ": " + jflex.l10n.ErrorMessages.get(message));
+    err(msg + ": " + ErrorMessages.get(message));
   }
 
   /**
@@ -242,14 +241,14 @@ public final class Out {
    * @param line the line number of the position
    * @param column the column of the position
    */
-  public static void warning(File file, jflex.l10n.ErrorMessages message, int line, int column) {
+  public static void warning(File file, ErrorMessages.ErrorMessage message, int line, int column) {
 
     String msg = NL + "Warning";
     if (file != null) msg += " in file \"" + file + "\"";
     if (line >= 0) msg = msg + " (line " + (line + 1) + ")";
 
     try {
-      err(msg + ": " + NL + jflex.l10n.ErrorMessages.get(message));
+      err(msg + ": " + NL + ErrorMessages.get(message));
     } catch (ArrayIndexOutOfBoundsException e) {
       err(msg);
     }
@@ -276,11 +275,11 @@ public final class Out {
    * print error message (code)
    *
    * @param message the code of the error message
-   * @see jflex.l10n.ErrorMessages
+   * @see ErrorMessages
    */
-  public static void error(jflex.l10n.ErrorMessages message) {
+  public static void error(ErrorMessages.ErrorMessage message) {
     errors++;
-    err(NL + "Error: " + jflex.l10n.ErrorMessages.get(message));
+    err(NL + "Error: " + ErrorMessages.get(message));
   }
 
   /**
@@ -288,11 +287,11 @@ public final class Out {
    *
    * @param data data to insert into the message
    * @param message the code of the error message
-   * @see jflex.l10n.ErrorMessages
+   * @see ErrorMessages
    */
-  public static void error(jflex.l10n.ErrorMessages message, String data) {
+  public static void error(ErrorMessages.ErrorMessage message, String data) {
     errors++;
-    err(NL + "Error: " + jflex.l10n.ErrorMessages.get(message, data));
+    err(NL + "Error: " + ErrorMessages.get(message, data));
   }
 
   /**
@@ -301,9 +300,9 @@ public final class Out {
    * @param message the code of the error message
    * @param file the file it occurred for
    */
-  public static void error(jflex.l10n.ErrorMessages message, File file) {
+  public static void error(ErrorMessages.ErrorMessage message, File file) {
     errors++;
-    err(NL + "Error: " + jflex.l10n.ErrorMessages.get(message) + " (" + file + ")");
+    err(NL + "Error: " + ErrorMessages.get(message) + " (" + file + ")");
   }
 
   /**
@@ -314,7 +313,7 @@ public final class Out {
    * @param line the line number of error position
    * @param column the column of error position
    */
-  public static void error(File file, jflex.l10n.ErrorMessages message, int line, int column) {
+  public static void error(File file, ErrorMessages.ErrorMessage message, int line, int column) {
 
     String msg = NL + "Error";
     if (file != null) msg += " in file \"" + file + "\"";
@@ -379,7 +378,7 @@ public final class Out {
    *
    * @param file the file to read
    * @param line the line number to get
-   * @throw IOException if any error occurs
+   * @throws IOException if any error occurs
    */
   private static String getLine(File file, int line) throws IOException {
     BufferedReader reader = new BufferedReader(new FileReader(file));

--- a/jflex/src/main/java/jflex/core/ScannerException.java
+++ b/jflex/src/main/java/jflex/core/ScannerException.java
@@ -25,11 +25,11 @@ public class ScannerException extends RuntimeException {
 
   public int line;
   public int column;
-  public jflex.l10n.ErrorMessages message;
+  public ErrorMessages.ErrorMessage message;
   public File file;
 
   private ScannerException(
-      File file, String text, jflex.l10n.ErrorMessages message, int line, int column) {
+      File file, String text, ErrorMessages.ErrorMessage message, int line, int column) {
     super(text);
     this.file = file;
     this.message = message;
@@ -42,8 +42,8 @@ public class ScannerException extends RuntimeException {
    *
    * @param message the code for the error description presented to the user.
    */
-  public ScannerException(jflex.l10n.ErrorMessages message) {
-    this(null, jflex.l10n.ErrorMessages.get(message), message, -1, -1);
+  public ScannerException(ErrorMessages.ErrorMessage message) {
+    this(null, ErrorMessages.get(message), message, -1, -1);
   }
 
   /**
@@ -52,7 +52,7 @@ public class ScannerException extends RuntimeException {
    * @param file the file in which the error occurred
    * @param message the code for the error description presented to the user.
    */
-  public ScannerException(File file, jflex.l10n.ErrorMessages message) {
+  public ScannerException(File file, ErrorMessages.ErrorMessage message) {
     this(file, jflex.l10n.ErrorMessages.get(message), message, -1, -1);
   }
 
@@ -62,7 +62,7 @@ public class ScannerException extends RuntimeException {
    * @param message the code for the error description presented to the user.
    * @param line the number of the line in the specification that contains the error
    */
-  public ScannerException(jflex.l10n.ErrorMessages message, int line) {
+  public ScannerException(ErrorMessages.ErrorMessage message, int line) {
     this(null, jflex.l10n.ErrorMessages.get(message), message, line, -1);
   }
 
@@ -73,7 +73,7 @@ public class ScannerException extends RuntimeException {
    * @param line the number of the line in the specification that contains the error
    * @param file a {@link java.io.File} object.
    */
-  public ScannerException(File file, jflex.l10n.ErrorMessages message, int line) {
+  public ScannerException(File file, ErrorMessages.ErrorMessage message, int line) {
     this(file, jflex.l10n.ErrorMessages.get(message), message, line, -1);
   }
 
@@ -85,7 +85,7 @@ public class ScannerException extends RuntimeException {
    * @param column the column where the error starts
    * @param file a {@link java.io.File} object.
    */
-  public ScannerException(File file, jflex.l10n.ErrorMessages message, int line, int column) {
+  public ScannerException(File file, ErrorMessages.ErrorMessage message, int line, int column) {
     this(file, ErrorMessages.get(message), message, line, column);
   }
 }

--- a/jflex/src/main/java/jflex/core/Skeleton.java
+++ b/jflex/src/main/java/jflex/core/Skeleton.java
@@ -98,17 +98,17 @@ public class Skeleton {
       throw new IllegalArgumentException("Skeleton file must not be null"); // $NON-NLS-1$
 
     if (!skeletonFile.isFile() || !skeletonFile.canRead()) {
-      Out.error(jflex.l10n.ErrorMessages.CANNOT_READ_SKEL, skeletonFile.toString());
+      Out.error(ErrorMessages.CANNOT_READ_SKEL, skeletonFile.toString());
       throw new GeneratorException();
     }
 
-    Out.println(jflex.l10n.ErrorMessages.READING_SKEL, skeletonFile.toString());
+    Out.println(ErrorMessages.READING_SKEL, skeletonFile.toString());
 
     try (BufferedReader reader =
         Files.newBufferedReader(Paths.get(skeletonFile.toString()), UTF_8)) {
       readSkel(reader);
     } catch (IOException e) {
-      Out.error(jflex.l10n.ErrorMessages.SKEL_IO_ERROR);
+      Out.error(ErrorMessages.SKEL_IO_ERROR);
       throw new GeneratorException();
     }
   }
@@ -138,7 +138,7 @@ public class Skeleton {
     if (section.length() > 0) lines.add(section.toString());
 
     if (lines.size() != size) {
-      Out.error(jflex.l10n.ErrorMessages.WRONG_SKELETON);
+      Out.error(ErrorMessages.WRONG_SKELETON);
       throw new GeneratorException();
     }
 
@@ -187,7 +187,7 @@ public class Skeleton {
     }
 
     if (url == null) {
-      Out.error(jflex.l10n.ErrorMessages.SKEL_IO_ERROR_DEFAULT);
+      Out.error(ErrorMessages.SKEL_IO_ERROR_DEFAULT);
       throw new GeneratorException();
     }
 

--- a/jflex/src/main/java/jflex/generator/LexGenerator.java
+++ b/jflex/src/main/java/jflex/generator/LexGenerator.java
@@ -55,7 +55,7 @@ public class LexGenerator {
 
     try (Reader inputReader =
         new InputStreamReader(Files.newInputStream(Paths.get(inputFile.toString())), encoding)) {
-      Out.println(jflex.l10n.ErrorMessages.READING, inputFile.toString());
+      Out.println(ErrorMessages.READING, inputFile.toString());
       LexScan scanner = new LexScan(inputReader);
       scanner.setFile(inputFile);
       LexParse parser = new LexParse(scanner);
@@ -64,24 +64,20 @@ public class LexGenerator {
 
       Out.checkErrors();
 
-      if (Options.dump)
-        Out.dump(
-            jflex.l10n.ErrorMessages.get(jflex.l10n.ErrorMessages.NFA_IS) + Out.NL + nfa + Out.NL);
+      if (Options.dump) Out.dump(ErrorMessages.get(ErrorMessages.NFA_IS) + Out.NL + nfa + Out.NL);
 
       if (Options.dot) nfa.writeDot(Emitter.normalize("nfa.dot", null)); // $NON-NLS-1$
 
-      Out.println(jflex.l10n.ErrorMessages.NFA_STATES, nfa.numStates());
+      Out.println(ErrorMessages.NFA_STATES, nfa.numStates());
 
       time.start();
       DFA dfa = nfa.getDFA();
       time.stop();
-      Out.time(jflex.l10n.ErrorMessages.DFA_TOOK, time);
+      Out.time(ErrorMessages.DFA_TOOK, time);
 
       dfa.checkActions(scanner, parser);
 
-      if (Options.dump)
-        Out.dump(
-            jflex.l10n.ErrorMessages.get(jflex.l10n.ErrorMessages.DFA_IS) + Out.NL + dfa + Out.NL);
+      if (Options.dump) Out.dump(ErrorMessages.get(ErrorMessages.DFA_IS) + Out.NL + dfa + Out.NL);
 
       if (Options.dot) dfa.writeDot(Emitter.normalize("dfa-big.dot", null)); // $NON-NLS-1$
 
@@ -91,10 +87,9 @@ public class LexGenerator {
       dfa.minimize();
       time.stop();
 
-      Out.time(jflex.l10n.ErrorMessages.MIN_TOOK, time);
+      Out.time(ErrorMessages.MIN_TOOK, time);
 
-      if (Options.dump)
-        Out.dump(jflex.l10n.ErrorMessages.get(jflex.l10n.ErrorMessages.MIN_DFA_IS) + Out.NL + dfa);
+      if (Options.dump) Out.dump(ErrorMessages.get(ErrorMessages.MIN_DFA_IS) + Out.NL + dfa);
 
       if (Options.dot) dfa.writeDot(Emitter.normalize("dfa-min.dot", null)); // $NON-NLS-1$
 
@@ -105,11 +100,11 @@ public class LexGenerator {
 
       time.stop();
 
-      Out.time(jflex.l10n.ErrorMessages.WRITE_TOOK, time);
+      Out.time(ErrorMessages.WRITE_TOOK, time);
 
       totalTime.stop();
 
-      Out.time(jflex.l10n.ErrorMessages.TOTAL_TIME, totalTime);
+      Out.time(ErrorMessages.TOTAL_TIME, totalTime);
       return emitter.outputFileName;
     } catch (ScannerException e) {
       Out.error(e.file, e.message, e.line, e.column);
@@ -118,7 +113,7 @@ public class LexGenerator {
       Out.error(e.getMessage());
       throw new GeneratorException(e);
     } catch (IOException e) {
-      Out.error(jflex.l10n.ErrorMessages.IO_ERROR, e.toString());
+      Out.error(ErrorMessages.IO_ERROR, e.toString());
       throw new GeneratorException(e);
     } catch (OutOfMemoryError e) {
       Out.error(ErrorMessages.OUT_OF_MEMORY);

--- a/jflex/src/main/java/jflex/l10n/ErrorMessages.java
+++ b/jflex/src/main/java/jflex/l10n/ErrorMessages.java
@@ -22,16 +22,181 @@ import java.util.ResourceBundle;
  * @version JFlex 1.8.0-SNAPSHOT
  */
 public class ErrorMessages {
-  private String key;
+
+  // typesafe enumeration (generated, do not edit)
+  /** Constant {@code UNTERMINATED_STR} */
+  public static ErrorMessage UNTERMINATED_STR = new ErrorMessage("UNTERMINATED_STR");
+  /** Constant {@code EOF_WO_ACTION} */
+  public static ErrorMessage EOF_WO_ACTION = new ErrorMessage("EOF_WO_ACTION");
+  /** Constant {@code UNKNOWN_OPTION} */
+  public static ErrorMessage UNKNOWN_OPTION = new ErrorMessage("UNKNOWN_OPTION");
+  /** Constant {@code UNEXPECTED_CHAR} */
+  public static ErrorMessage UNEXPECTED_CHAR = new ErrorMessage("UNEXPECTED_CHAR");
+  /** Constant {@code UNEXPECTED_NL} */
+  public static ErrorMessage UNEXPECTED_NL = new ErrorMessage("UNEXPECTED_NL");
+  /** Constant {@code LEXSTATE_UNDECL} */
+  public static ErrorMessage LEXSTATE_UNDECL = new ErrorMessage("LEXSTATE_UNDECL");
+  /** Constant {@code REPEAT_ZERO} */
+  public static ErrorMessage REPEAT_ZERO = new ErrorMessage("REPEAT_ZERO");
+  /** Constant {@code REPEAT_GREATER} */
+  public static ErrorMessage REPEAT_GREATER = new ErrorMessage("REPEAT_GREATER");
+  /** Constant {@code REGEXP_EXPECTED} */
+  public static ErrorMessage REGEXP_EXPECTED = new ErrorMessage("REGEXP_EXPECTED");
+  /** Constant {@code MACRO_UNDECL} */
+  public static ErrorMessage MACRO_UNDECL = new ErrorMessage("MACRO_UNDECL");
+  /** Constant {@code CHARSET_2_SMALL} */
+  public static ErrorMessage CHARSET_2_SMALL = new ErrorMessage("CHARSET_2_SMALL");
+  /** Constant {@code CS2SMALL_STRING} */
+  public static ErrorMessage CS2SMALL_STRING = new ErrorMessage("CS2SMALL_STRING");
+  /** Constant {@code CS2SMALL_CHAR} */
+  public static ErrorMessage CS2SMALL_CHAR = new ErrorMessage("CS2SMALL_CHAR");
+  /** Constant {@code CHARCLASS_MACRO} */
+  public static ErrorMessage CHARCLASS_MACRO = new ErrorMessage("CHARCLASS_MACRO");
+  /** Constant {@code UNKNOWN_SYNTAX} */
+  public static ErrorMessage UNKNOWN_SYNTAX = new ErrorMessage("UNKNOWN_SYNTAX");
+  /** Constant {@code SYNTAX_ERROR} */
+  public static ErrorMessage SYNTAX_ERROR = new ErrorMessage("SYNTAX_ERROR");
+  /** Constant {@code NOT_AT_BOL} */
+  public static ErrorMessage NOT_AT_BOL = new ErrorMessage("NOT_AT_BOL");
+  /** Constant {@code EOF_IN_ACTION} */
+  public static ErrorMessage EOF_IN_ACTION = new ErrorMessage("EOF_IN_ACTION");
+  /** Constant {@code EOF_IN_COMMENT} */
+  public static ErrorMessage EOF_IN_COMMENT = new ErrorMessage("EOF_IN_COMMENT");
+  /** Constant {@code EOF_IN_STRING} */
+  public static ErrorMessage EOF_IN_STRING = new ErrorMessage("EOF_IN_STRING");
+  /** Constant {@code EOF_IN_MACROS} */
+  public static ErrorMessage EOF_IN_MACROS = new ErrorMessage("EOF_IN_MACROS");
+  /** Constant {@code EOF_IN_STATES} */
+  public static ErrorMessage EOF_IN_STATES = new ErrorMessage("EOF_IN_STATES");
+  /** Constant {@code EOF_IN_REGEXP} */
+  public static ErrorMessage EOF_IN_REGEXP = new ErrorMessage("EOF_IN_REGEXP");
+  /** Constant {@code UNEXPECTED_EOF} */
+  public static ErrorMessage UNEXPECTED_EOF = new ErrorMessage("UNEXPECTED_EOF");
+  /** Constant {@code NO_LEX_SPEC} */
+  public static ErrorMessage NO_LEX_SPEC = new ErrorMessage("NO_LEX_SPEC");
+  /** Constant {@code NO_LAST_ACTION} */
+  public static ErrorMessage NO_LAST_ACTION = new ErrorMessage("NO_LAST_ACTION");
+  /** Constant {@code NO_DIRECTORY} */
+  public static ErrorMessage NO_DIRECTORY = new ErrorMessage("NO_DIRECTORY");
+  /** Constant {@code NO_SKEL_FILE} */
+  public static ErrorMessage NO_SKEL_FILE = new ErrorMessage("NO_SKEL_FILE");
+  /** Constant {@code WRONG_SKELETON} */
+  public static ErrorMessage WRONG_SKELETON = new ErrorMessage("WRONG_SKELETON");
+  /** Constant {@code OUT_OF_MEMORY} */
+  public static ErrorMessage OUT_OF_MEMORY = new ErrorMessage("OUT_OF_MEMORY");
+  /** Constant {@code QUIL_INITTHROW} */
+  public static ErrorMessage QUIL_INITTHROW = new ErrorMessage("QUIL_INITTHROW");
+  /** Constant {@code QUIL_EOFTHROW} */
+  public static ErrorMessage QUIL_EOFTHROW = new ErrorMessage("QUIL_EOFTHROW");
+  /** Constant {@code QUIL_YYLEXTHROW} */
+  public static ErrorMessage QUIL_YYLEXTHROW = new ErrorMessage("QUIL_YYLEXTHROW");
+  /** Constant {@code ZERO_STATES} */
+  public static ErrorMessage ZERO_STATES = new ErrorMessage("ZERO_STATES");
+  /** Constant {@code NO_BUFFER_SIZE} */
+  public static ErrorMessage NO_BUFFER_SIZE = new ErrorMessage("NO_BUFFER_SIZE");
+  /** Constant {@code NOT_READABLE} */
+  public static ErrorMessage NOT_READABLE = new ErrorMessage("NOT_READABLE");
+  /** Constant {@code FILE_CYCLE} */
+  public static ErrorMessage FILE_CYCLE = new ErrorMessage("FILE_CYCLE");
+  /** Constant {@code FILE_WRITE} */
+  public static ErrorMessage FILE_WRITE = new ErrorMessage("FILE_WRITE");
+  /** Constant {@code QUIL_SCANERROR} */
+  public static ErrorMessage QUIL_SCANERROR = new ErrorMessage("QUIL_SCANERROR");
+  /** Constant {@code NEVER_MATCH} */
+  public static ErrorMessage NEVER_MATCH = new ErrorMessage("NEVER_MATCH");
+  /** Constant {@code QUIL_THROW} */
+  public static ErrorMessage QUIL_THROW = new ErrorMessage("QUIL_THROW");
+  /** Constant {@code EOL_IN_CHARCLASS} */
+  public static ErrorMessage EOL_IN_CHARCLASS = new ErrorMessage("EOL_IN_CHARCLASS");
+  /** Constant {@code QUIL_CUPSYM} */
+  public static ErrorMessage QUIL_CUPSYM = new ErrorMessage("QUIL_CUPSYM");
+  /** Constant {@code CUPSYM_AFTER_CUP} */
+  public static ErrorMessage CUPSYM_AFTER_CUP = new ErrorMessage("CUPSYM_AFTER_CUP");
+  /** Constant {@code ALREADY_RUNNING} */
+  public static ErrorMessage ALREADY_RUNNING = new ErrorMessage("ALREADY_RUNNING");
+  /** Constant {@code CANNOT_READ_SKEL} */
+  public static ErrorMessage CANNOT_READ_SKEL = new ErrorMessage("CANNOT_READ_SKEL");
+  /** Constant {@code READING_SKEL} */
+  public static ErrorMessage READING_SKEL = new ErrorMessage("READING_SKEL");
+  /** Constant {@code SKEL_IO_ERROR} */
+  public static ErrorMessage SKEL_IO_ERROR = new ErrorMessage("SKEL_IO_ERROR");
+  /** Constant {@code SKEL_IO_ERROR_DEFAULT} */
+  public static ErrorMessage SKEL_IO_ERROR_DEFAULT = new ErrorMessage("SKEL_IO_ERROR_DEFAULT");
+  /** Constant {@code READING} */
+  public static ErrorMessage READING = new ErrorMessage("READING");
+  /** Constant {@code CANNOT_OPEN} */
+  public static ErrorMessage CANNOT_OPEN = new ErrorMessage("CANNOT_OPEN");
+  /** Constant {@code NFA_IS} */
+  public static ErrorMessage NFA_IS = new ErrorMessage("NFA_IS");
+  /** Constant {@code NFA_STATES} */
+  public static ErrorMessage NFA_STATES = new ErrorMessage("NFA_STATES");
+  /** Constant {@code DFA_TOOK} */
+  public static ErrorMessage DFA_TOOK = new ErrorMessage("DFA_TOOK");
+  /** Constant {@code DFA_IS} */
+  public static ErrorMessage DFA_IS = new ErrorMessage("DFA_IS");
+  /** Constant {@code MIN_TOOK} */
+  public static ErrorMessage MIN_TOOK = new ErrorMessage("MIN_TOOK");
+  /** Constant {@code MIN_DFA_IS} */
+  public static ErrorMessage MIN_DFA_IS = new ErrorMessage("MIN_DFA_IS");
+  /** Constant {@code WRITE_TOOK} */
+  public static ErrorMessage WRITE_TOOK = new ErrorMessage("WRITE_TOOK");
+  /** Constant {@code TOTAL_TIME} */
+  public static ErrorMessage TOTAL_TIME = new ErrorMessage("TOTAL_TIME");
+  /** Constant {@code IO_ERROR} */
+  public static ErrorMessage IO_ERROR = new ErrorMessage("IO_ERROR");
+  /** Constant {@code THIS_IS_JFLEX} */
+  public static ErrorMessage THIS_IS_JFLEX = new ErrorMessage("THIS_IS_JFLEX");
+  /** Constant {@code UNKNOWN_COMMANDLINE} */
+  public static ErrorMessage UNKNOWN_COMMANDLINE = new ErrorMessage("UNKNOWN_COMMANDLINE");
+  /** Constant {@code MACRO_CYCLE} */
+  public static ErrorMessage MACRO_CYCLE = new ErrorMessage("MACRO_CYCLE");
+  /** Constant {@code MACRO_DEF_MISSING} */
+  public static ErrorMessage MACRO_DEF_MISSING = new ErrorMessage("MACRO_DEF_MISSING");
+  /** Constant {@code PARSING_TOOK} */
+  public static ErrorMessage PARSING_TOOK = new ErrorMessage("PARSING_TOOK");
+  /** Constant {@code NFA_TOOK} */
+  public static ErrorMessage NFA_TOOK = new ErrorMessage("NFA_TOOK");
+  /** Constant {@code LOOKAHEAD_NEEDS_ACTION} */
+  public static ErrorMessage LOOKAHEAD_NEEDS_ACTION = new ErrorMessage("LOOKAHEAD_NEEDS_ACTION");
+  /** Constant {@code EMPTY_MATCH} */
+  public static ErrorMessage EMPTY_MATCH = new ErrorMessage("EMPTY_MATCH");
+  /** Constant {@code EMPTY_MATCH_LOOK} */
+  public static ErrorMessage EMPTY_MATCH_LOOK = new ErrorMessage("EMPTY_MATCH_LOOK");
+  /** Constant {@code CTOR_ARG} */
+  public static ErrorMessage CTOR_ARG = new ErrorMessage("CTOR_ARG");
+  /** Constant {@code CTOR_DEBUG} */
+  public static ErrorMessage CTOR_DEBUG = new ErrorMessage("CTOR_DEBUG");
+  /** Constant {@code INT_AND_TYPE} */
+  public static ErrorMessage INT_AND_TYPE = new ErrorMessage("INT_AND_TYPE");
+  /** Constant {@code UNSUPPORTED_UNICODE_VERSION} */
+  public static ErrorMessage UNSUPPORTED_UNICODE_VERSION =
+      new ErrorMessage("UNSUPPORTED_UNICODE_VERSION");
+  /** Constant {@code UNSUPPORTED_UNICODE_VERSION_SUPPORTED_ARE} */
+  public static ErrorMessage UNSUPPORTED_UNICODE_VERSION_SUPPORTED_ARE =
+      new ErrorMessage("UNSUPPORTED_UNICODE_VERSION_SUPPORTED_ARE");
+  /** Constant {@code INVALID_UNICODE_PROPERTY} */
+  public static ErrorMessage INVALID_UNICODE_PROPERTY =
+      new ErrorMessage("INVALID_UNICODE_PROPERTY");
+  /** Constant {@code DOT_BAR_NEWLINE_DOES_NOT_MATCH_ALL_CHARS} */
+  public static ErrorMessage DOT_BAR_NEWLINE_DOES_NOT_MATCH_ALL_CHARS =
+      new ErrorMessage("DOT_BAR_NEWLINE_DOES_NOT_MATCH_ALL_CHARS");
+  /** Constant {@code PROPS_ARG_REQUIRES_UNICODE_VERSION} */
+  public static ErrorMessage PROPS_ARG_REQUIRES_UNICODE_VERSION =
+      new ErrorMessage("PROPS_ARG_REQUIRES_UNICODE_VERSION");
+  /** Constant {@code IMPOSSIBLE_CHARCLASS_RANGE} */
+  public static ErrorMessage IMPOSSIBLE_CHARCLASS_RANGE =
+      new ErrorMessage("IMPOSSIBLE_CHARCLASS_RANGE");
+  /** Constant {@code CODEPOINT_OUT_OF_RANGE} */
+  public static ErrorMessage CODEPOINT_OUT_OF_RANGE = new ErrorMessage("CODEPOINT_OUT_OF_RANGE");
+  /** Constant {@code NO_ENCODING} */
+  public static ErrorMessage NO_ENCODING = new ErrorMessage("NO_ENCODING");
+  /** Constant {@code CHARSET_NOT_SUPPORTED} */
+  public static ErrorMessage CHARSET_NOT_SUPPORTED = new ErrorMessage("CHARSET_NOT_SUPPORTED");
 
   /* not final static, because initializing here seems too early
    * for OS/2 JDK 1.1.8. See bug 1065521.
    */
   private static ResourceBundle resourceBundle = null;
-
-  private ErrorMessages(String key) {
-    this.key = key;
-  }
 
   /**
    * Returns a localized representation of the error messages.
@@ -39,7 +204,7 @@ public class ErrorMessages {
    * @param msg a {@link ErrorMessages} object.
    * @return a {@link java.lang.String} representation of the errors.
    */
-  public static String get(ErrorMessages msg) {
+  public static String get(ErrorMessage msg) {
     if (resourceBundle == null) {
       resourceBundle = ResourceBundle.getBundle("jflex.Messages");
     }
@@ -60,173 +225,11 @@ public class ErrorMessages {
     return MessageFormat.format(get(msg), args);
   }
 
-  // typesafe enumeration (generated, do not edit)
-  /** Constant {@code UNTERMINATED_STR} */
-  public static ErrorMessages UNTERMINATED_STR = new ErrorMessages("UNTERMINATED_STR");
-  /** Constant {@code EOF_WO_ACTION} */
-  public static ErrorMessages EOF_WO_ACTION = new ErrorMessages("EOF_WO_ACTION");
-  /** Constant {@code UNKNOWN_OPTION} */
-  public static ErrorMessages UNKNOWN_OPTION = new ErrorMessages("UNKNOWN_OPTION");
-  /** Constant {@code UNEXPECTED_CHAR} */
-  public static ErrorMessages UNEXPECTED_CHAR = new ErrorMessages("UNEXPECTED_CHAR");
-  /** Constant {@code UNEXPECTED_NL} */
-  public static ErrorMessages UNEXPECTED_NL = new ErrorMessages("UNEXPECTED_NL");
-  /** Constant {@code LEXSTATE_UNDECL} */
-  public static ErrorMessages LEXSTATE_UNDECL = new ErrorMessages("LEXSTATE_UNDECL");
-  /** Constant {@code REPEAT_ZERO} */
-  public static ErrorMessages REPEAT_ZERO = new ErrorMessages("REPEAT_ZERO");
-  /** Constant {@code REPEAT_GREATER} */
-  public static ErrorMessages REPEAT_GREATER = new ErrorMessages("REPEAT_GREATER");
-  /** Constant {@code REGEXP_EXPECTED} */
-  public static ErrorMessages REGEXP_EXPECTED = new ErrorMessages("REGEXP_EXPECTED");
-  /** Constant {@code MACRO_UNDECL} */
-  public static ErrorMessages MACRO_UNDECL = new ErrorMessages("MACRO_UNDECL");
-  /** Constant {@code CHARSET_2_SMALL} */
-  public static ErrorMessages CHARSET_2_SMALL = new ErrorMessages("CHARSET_2_SMALL");
-  /** Constant {@code CS2SMALL_STRING} */
-  public static ErrorMessages CS2SMALL_STRING = new ErrorMessages("CS2SMALL_STRING");
-  /** Constant {@code CS2SMALL_CHAR} */
-  public static ErrorMessages CS2SMALL_CHAR = new ErrorMessages("CS2SMALL_CHAR");
-  /** Constant {@code CHARCLASS_MACRO} */
-  public static ErrorMessages CHARCLASS_MACRO = new ErrorMessages("CHARCLASS_MACRO");
-  /** Constant {@code UNKNOWN_SYNTAX} */
-  public static ErrorMessages UNKNOWN_SYNTAX = new ErrorMessages("UNKNOWN_SYNTAX");
-  /** Constant {@code SYNTAX_ERROR} */
-  public static ErrorMessages SYNTAX_ERROR = new ErrorMessages("SYNTAX_ERROR");
-  /** Constant {@code NOT_AT_BOL} */
-  public static ErrorMessages NOT_AT_BOL = new ErrorMessages("NOT_AT_BOL");
-  /** Constant {@code EOF_IN_ACTION} */
-  public static ErrorMessages EOF_IN_ACTION = new ErrorMessages("EOF_IN_ACTION");
-  /** Constant {@code EOF_IN_COMMENT} */
-  public static ErrorMessages EOF_IN_COMMENT = new ErrorMessages("EOF_IN_COMMENT");
-  /** Constant {@code EOF_IN_STRING} */
-  public static ErrorMessages EOF_IN_STRING = new ErrorMessages("EOF_IN_STRING");
-  /** Constant {@code EOF_IN_MACROS} */
-  public static ErrorMessages EOF_IN_MACROS = new ErrorMessages("EOF_IN_MACROS");
-  /** Constant {@code EOF_IN_STATES} */
-  public static ErrorMessages EOF_IN_STATES = new ErrorMessages("EOF_IN_STATES");
-  /** Constant {@code EOF_IN_REGEXP} */
-  public static ErrorMessages EOF_IN_REGEXP = new ErrorMessages("EOF_IN_REGEXP");
-  /** Constant {@code UNEXPECTED_EOF} */
-  public static ErrorMessages UNEXPECTED_EOF = new ErrorMessages("UNEXPECTED_EOF");
-  /** Constant {@code NO_LEX_SPEC} */
-  public static ErrorMessages NO_LEX_SPEC = new ErrorMessages("NO_LEX_SPEC");
-  /** Constant {@code NO_LAST_ACTION} */
-  public static ErrorMessages NO_LAST_ACTION = new ErrorMessages("NO_LAST_ACTION");
-  /** Constant {@code NO_DIRECTORY} */
-  public static ErrorMessages NO_DIRECTORY = new ErrorMessages("NO_DIRECTORY");
-  /** Constant {@code NO_SKEL_FILE} */
-  public static ErrorMessages NO_SKEL_FILE = new ErrorMessages("NO_SKEL_FILE");
-  /** Constant {@code WRONG_SKELETON} */
-  public static ErrorMessages WRONG_SKELETON = new ErrorMessages("WRONG_SKELETON");
-  /** Constant {@code OUT_OF_MEMORY} */
-  public static ErrorMessages OUT_OF_MEMORY = new ErrorMessages("OUT_OF_MEMORY");
-  /** Constant {@code QUIL_INITTHROW} */
-  public static ErrorMessages QUIL_INITTHROW = new ErrorMessages("QUIL_INITTHROW");
-  /** Constant {@code QUIL_EOFTHROW} */
-  public static ErrorMessages QUIL_EOFTHROW = new ErrorMessages("QUIL_EOFTHROW");
-  /** Constant {@code QUIL_YYLEXTHROW} */
-  public static ErrorMessages QUIL_YYLEXTHROW = new ErrorMessages("QUIL_YYLEXTHROW");
-  /** Constant {@code ZERO_STATES} */
-  public static ErrorMessages ZERO_STATES = new ErrorMessages("ZERO_STATES");
-  /** Constant {@code NO_BUFFER_SIZE} */
-  public static ErrorMessages NO_BUFFER_SIZE = new ErrorMessages("NO_BUFFER_SIZE");
-  /** Constant {@code NOT_READABLE} */
-  public static ErrorMessages NOT_READABLE = new ErrorMessages("NOT_READABLE");
-  /** Constant {@code FILE_CYCLE} */
-  public static ErrorMessages FILE_CYCLE = new ErrorMessages("FILE_CYCLE");
-  /** Constant {@code FILE_WRITE} */
-  public static ErrorMessages FILE_WRITE = new ErrorMessages("FILE_WRITE");
-  /** Constant {@code QUIL_SCANERROR} */
-  public static ErrorMessages QUIL_SCANERROR = new ErrorMessages("QUIL_SCANERROR");
-  /** Constant {@code NEVER_MATCH} */
-  public static ErrorMessages NEVER_MATCH = new ErrorMessages("NEVER_MATCH");
-  /** Constant {@code QUIL_THROW} */
-  public static ErrorMessages QUIL_THROW = new ErrorMessages("QUIL_THROW");
-  /** Constant {@code EOL_IN_CHARCLASS} */
-  public static ErrorMessages EOL_IN_CHARCLASS = new ErrorMessages("EOL_IN_CHARCLASS");
-  /** Constant {@code QUIL_CUPSYM} */
-  public static ErrorMessages QUIL_CUPSYM = new ErrorMessages("QUIL_CUPSYM");
-  /** Constant {@code CUPSYM_AFTER_CUP} */
-  public static ErrorMessages CUPSYM_AFTER_CUP = new ErrorMessages("CUPSYM_AFTER_CUP");
-  /** Constant {@code ALREADY_RUNNING} */
-  public static ErrorMessages ALREADY_RUNNING = new ErrorMessages("ALREADY_RUNNING");
-  /** Constant {@code CANNOT_READ_SKEL} */
-  public static ErrorMessages CANNOT_READ_SKEL = new ErrorMessages("CANNOT_READ_SKEL");
-  /** Constant {@code READING_SKEL} */
-  public static ErrorMessages READING_SKEL = new ErrorMessages("READING_SKEL");
-  /** Constant {@code SKEL_IO_ERROR} */
-  public static ErrorMessages SKEL_IO_ERROR = new ErrorMessages("SKEL_IO_ERROR");
-  /** Constant {@code SKEL_IO_ERROR_DEFAULT} */
-  public static ErrorMessages SKEL_IO_ERROR_DEFAULT = new ErrorMessages("SKEL_IO_ERROR_DEFAULT");
-  /** Constant {@code READING} */
-  public static ErrorMessages READING = new ErrorMessages("READING");
-  /** Constant {@code CANNOT_OPEN} */
-  public static ErrorMessages CANNOT_OPEN = new ErrorMessages("CANNOT_OPEN");
-  /** Constant {@code NFA_IS} */
-  public static ErrorMessages NFA_IS = new ErrorMessages("NFA_IS");
-  /** Constant {@code NFA_STATES} */
-  public static ErrorMessages NFA_STATES = new ErrorMessages("NFA_STATES");
-  /** Constant {@code DFA_TOOK} */
-  public static ErrorMessages DFA_TOOK = new ErrorMessages("DFA_TOOK");
-  /** Constant {@code DFA_IS} */
-  public static ErrorMessages DFA_IS = new ErrorMessages("DFA_IS");
-  /** Constant {@code MIN_TOOK} */
-  public static ErrorMessages MIN_TOOK = new ErrorMessages("MIN_TOOK");
-  /** Constant {@code MIN_DFA_IS} */
-  public static ErrorMessages MIN_DFA_IS = new ErrorMessages("MIN_DFA_IS");
-  /** Constant {@code WRITE_TOOK} */
-  public static ErrorMessages WRITE_TOOK = new ErrorMessages("WRITE_TOOK");
-  /** Constant {@code TOTAL_TIME} */
-  public static ErrorMessages TOTAL_TIME = new ErrorMessages("TOTAL_TIME");
-  /** Constant {@code IO_ERROR} */
-  public static ErrorMessages IO_ERROR = new ErrorMessages("IO_ERROR");
-  /** Constant {@code THIS_IS_JFLEX} */
-  public static ErrorMessages THIS_IS_JFLEX = new ErrorMessages("THIS_IS_JFLEX");
-  /** Constant {@code UNKNOWN_COMMANDLINE} */
-  public static ErrorMessages UNKNOWN_COMMANDLINE = new ErrorMessages("UNKNOWN_COMMANDLINE");
-  /** Constant {@code MACRO_CYCLE} */
-  public static ErrorMessages MACRO_CYCLE = new ErrorMessages("MACRO_CYCLE");
-  /** Constant {@code MACRO_DEF_MISSING} */
-  public static ErrorMessages MACRO_DEF_MISSING = new ErrorMessages("MACRO_DEF_MISSING");
-  /** Constant {@code PARSING_TOOK} */
-  public static ErrorMessages PARSING_TOOK = new ErrorMessages("PARSING_TOOK");
-  /** Constant {@code NFA_TOOK} */
-  public static ErrorMessages NFA_TOOK = new ErrorMessages("NFA_TOOK");
-  /** Constant {@code LOOKAHEAD_NEEDS_ACTION} */
-  public static ErrorMessages LOOKAHEAD_NEEDS_ACTION = new ErrorMessages("LOOKAHEAD_NEEDS_ACTION");
-  /** Constant {@code EMPTY_MATCH} */
-  public static ErrorMessages EMPTY_MATCH = new ErrorMessages("EMPTY_MATCH");
-  /** Constant {@code EMPTY_MATCH_LOOK} */
-  public static ErrorMessages EMPTY_MATCH_LOOK = new ErrorMessages("EMPTY_MATCH_LOOK");
-  /** Constant {@code CTOR_ARG} */
-  public static ErrorMessages CTOR_ARG = new ErrorMessages("CTOR_ARG");
-  /** Constant {@code CTOR_DEBUG} */
-  public static ErrorMessages CTOR_DEBUG = new ErrorMessages("CTOR_DEBUG");
-  /** Constant {@code INT_AND_TYPE} */
-  public static ErrorMessages INT_AND_TYPE = new ErrorMessages("INT_AND_TYPE");
-  /** Constant {@code UNSUPPORTED_UNICODE_VERSION} */
-  public static ErrorMessages UNSUPPORTED_UNICODE_VERSION =
-      new ErrorMessages("UNSUPPORTED_UNICODE_VERSION");
-  /** Constant {@code UNSUPPORTED_UNICODE_VERSION_SUPPORTED_ARE} */
-  public static ErrorMessages UNSUPPORTED_UNICODE_VERSION_SUPPORTED_ARE =
-      new ErrorMessages("UNSUPPORTED_UNICODE_VERSION_SUPPORTED_ARE");
-  /** Constant {@code INVALID_UNICODE_PROPERTY} */
-  public static ErrorMessages INVALID_UNICODE_PROPERTY =
-      new ErrorMessages("INVALID_UNICODE_PROPERTY");
-  /** Constant {@code DOT_BAR_NEWLINE_DOES_NOT_MATCH_ALL_CHARS} */
-  public static ErrorMessages DOT_BAR_NEWLINE_DOES_NOT_MATCH_ALL_CHARS =
-      new ErrorMessages("DOT_BAR_NEWLINE_DOES_NOT_MATCH_ALL_CHARS");
-  /** Constant {@code PROPS_ARG_REQUIRES_UNICODE_VERSION} */
-  public static ErrorMessages PROPS_ARG_REQUIRES_UNICODE_VERSION =
-      new ErrorMessages("PROPS_ARG_REQUIRES_UNICODE_VERSION");
-  /** Constant {@code IMPOSSIBLE_CHARCLASS_RANGE} */
-  public static ErrorMessages IMPOSSIBLE_CHARCLASS_RANGE =
-      new ErrorMessages("IMPOSSIBLE_CHARCLASS_RANGE");
-  /** Constant {@code CODEPOINT_OUT_OF_RANGE} */
-  public static ErrorMessages CODEPOINT_OUT_OF_RANGE = new ErrorMessages("CODEPOINT_OUT_OF_RANGE");
-  /** Constant {@code NO_ENCODING} */
-  public static ErrorMessages NO_ENCODING = new ErrorMessages("NO_ENCODING");
-  /** Constant {@code CHARSET_NOT_SUPPORTED} */
-  public static ErrorMessages CHARSET_NOT_SUPPORTED = new ErrorMessages("CHARSET_NOT_SUPPORTED");
+  private static class ErrorMessage {
+    private final String key;
+
+    private ErrorMessage(String key) {
+      this.key = key;
+    }
+  }
 }

--- a/jflex/src/main/java/jflex/l10n/ErrorMessages.java
+++ b/jflex/src/main/java/jflex/l10n/ErrorMessages.java
@@ -221,11 +221,11 @@ public class ErrorMessages {
    * @param msg a {@link ErrorMessages} containing the format string.
    * @return a {@link java.lang.String} object.
    */
-  public static String get(ErrorMessages msg, Object... args) {
+  public static String get(ErrorMessages.ErrorMessage msg, Object... args) {
     return MessageFormat.format(get(msg), args);
   }
 
-  private static class ErrorMessage {
+  public static class ErrorMessage {
     private final String key;
 
     private ErrorMessage(String key) {


### PR DESCRIPTION
The ErrorMessages remains as the constant holder. But each constant should be a _single_ ErrorMessage(no s).

Also, define constant before methods, as per code-style compliance from PMD
> Fields should be declared at the top of the class, before any method declarations, constructors, initializers or inner classes.
https://app.codacy.com/manual/regisd/jflex/file/39717832852/issues/source?bid=9096674&fileBranchId=9096674