### PR TITLE
Revert "Unit tests for BOL & EOL". Restore bol-0.input

### DIFF
--- a/testsuite/testcases/src/test/cases/bol/bol-0.input
+++ b/testsuite/testcases/src/test/cases/bol/bol-0.input
@@ -1,0 +1,8 @@
+hello
+  hello
+  hello  
+hello 
+  hello
+hello 
+ 
+sdfa


### PR DESCRIPTION
This partially reverts commit b3f1f036b888d6e3363dde0f03eeffcac95277df.

I accidentally moved the file out of `testsuite/testcases/src/test/cases`.

And the jflex-test-plugin use directory content to find tests (i.e. I accidentally completely removed the test with no test failure).