### PR TITLE
Disable ant build in test-examples.sh if command is missing

### DIFF
--- a/scripts/test-examples.sh
+++ b/scripts/test-examples.sh
@@ -14,6 +14,14 @@ if [[ $? -eq 0 ]]; then
 else
   MAKE=echo
 fi
+
+which ant
+if [[ $? -eq 0 ]]; then
+  ANT=make
+else
+  ANT=echo
+fi
+
 # Exit with error in case of error (see #242)
 set -e
 
@@ -40,8 +48,8 @@ logi "Example: cup-interpreter"
 cd cup-interpreter
 "$MVN" test
 # TODO(#384) Fix ant test
-# ant test
-ant build
+"$ANT" build
+# "$ANT" test
 "$MAKE" test
 cd ..
 
@@ -49,39 +57,38 @@ logi "Example: cup-java"
 cd cup-java
 "$MVN" test
 # Fix ant #384
-#ant test
-ant build
-ant test
+"$ANT" build
+"$ANT" test
 "$MAKE" test
 cd ..
 
 logi "Example: cup-lcalc"
 cd cup-lcalc
 "$MVN" test
-# ant test
+# "$ANT" test
 # make test
 cd ..
 
 logi "Example: simple"
 cd simple
 "$MVN" test
+"$ANT" build
 # Fix ant
-#ant test
-ant build
+#"$ANT" test
 # make test
 cd ..
 
 logi "Example: standalone"
 cd standalone
 "$MVN" test
-# ant test
+# "$ANT" test
 # make test
 cd ..
 
 logi "Example: zero-reader"
 cd zero-reader
 "$MVN" test
-# ant test
+# "$ANT" test
 "$MAKE" test
 cd ..
 


### PR DESCRIPTION
Replace `ant` by echo if the command is not available.
This disable ant on Travis, to work around sudden failure on Travis:

> scripts/test-examples.sh: line 44: ant: command not found
> The command "scripts/test-examples.sh" exited with 127.

https://travis-ci.org/jflex-de/jflex/jobs/616000480