### PR TITLE
Follow up on Migration tool

### DIFF
--- a/java/jflex/migration/BUILD
+++ b/java/jflex/migration/BUILD
@@ -17,7 +17,7 @@ java_library(
         ":model",
         ":test_case_parser",
         ":velocity_templates",
-        "//java/jflex/testing/testsuite/golden",
+        "//java/jflex/testing/testsuite/golden:model",
         "//java/jflex/util/javac:package_util",
         "//java/jflex/velocity",
         "//third_party/com/google/common/flogger",
@@ -35,7 +35,7 @@ java_library(
     ],
     deps = [
         ":model",
-        "//java/jflex/testing/testsuite/golden",
+        "//java/jflex/testing/testsuite/golden:model",
         "//java/jflex/velocity",
         "//third_party/com/google/guava",
         "//third_party/org/apache/velocity",
@@ -48,7 +48,7 @@ java_library(
         "TestCase.java",
     ],
     deps = [
-        "//java/jflex/testing/testsuite/golden",
+        "//java/jflex/testing/testsuite/golden:model",
     ],
 )
 

--- a/java/jflex/migration/BUILD.vm
+++ b/java/jflex/migration/BUILD.vm
@@ -29,17 +29,17 @@ java_test(
     srcs = [
         "${testClassName}.java",
     ],
+    data = [
+#foreach ( $golden in $goldens )
+        "$golden.InputFileName",
+        "$golden.OutputFileName",
+#end
+    ],
     deps = [
         ":${testName}_scanner",
         "//java/jflex/testing/diff",
         "//java/jflex/testing/testsuite/golden",
         "//third_party/com/google/guava",
         "//third_party/com/google/truth",
-    ],
-    data = [
-#foreach ( $golden in $goldens )
-        "$golden.InputFileName",
-        "$golden.OutputFileName",
-#end
     ],
 )

--- a/java/jflex/migration/Migrator.java
+++ b/java/jflex/migration/Migrator.java
@@ -139,10 +139,13 @@ public class Migrator {
       //noinspection ResultOfMethodCallIgnored
       outputDir.mkdirs();
     }
+    logger.atInfo().log("Generating into %s", outputDir);
     renderBuildFile(templateVars, outputDir);
     renderTestCase(templateVars, outputDir);
     copyGrammarFile(templateVars.flexGrammar, templateVars.javaPackage, outputDir);
     copyGoldenFiles(templateVars.goldens, outputDir);
+    logger.atInfo().log("Import the files in your workspace");
+    logger.atInfo().log("   cp -r %s $(bazel info workspace)/javatests/jflex/testcase", outputDir);
   }
 
   /** Generates the BUILD file for this test case. */
@@ -153,8 +156,9 @@ public class Migrator {
     try {
       // If there are multiple `.test` files in a directory, this is going to break.
       Preconditions.checkState(!outFile.exists(), "Attempting to override an existing BUILD file");
-    } catch (IllegalArgumentException e) {
-      throw new MigrationException("Please output to a clean directory", e);
+    } catch (IllegalStateException e) {
+      // throw new MigrationException("Please output to a clean directory", e);
+      logger.atWarning().log("Overriding %s", outFile);
     }
     try (OutputStream outputStream = new FileOutputStream(outFile)) {
       logger.atInfo().log("Generating %s", outFile);
@@ -207,7 +211,7 @@ public class Migrator {
   /** Copy the list of golden files. */
   private static void copyGoldenFiles(ImmutableList<GoldenInOutFilePair> goldens, File outputDir)
       throws MigrationException {
-    logger.atInfo().log("Copy Golden files to %s", outputDir.getAbsolutePath());
+    logger.atInfo().log("Copy %n pairs of olden files", goldens.size());
     try {
       for (GoldenInOutFilePair golden : goldens) {
         copyFile(golden.inputFile, outputDir);

--- a/java/jflex/migration/Migrator.java
+++ b/java/jflex/migration/Migrator.java
@@ -246,7 +246,8 @@ public class Migrator {
     Iterable<File> dirContent = Files.fileTraverser().breadthFirst(testCaseDir);
     return Streams.stream(dirContent)
         .filter(f -> isGoldenInputFile(test, f))
-        .map(f -> new GoldenInOutFilePair(test.getTestName(), f, getGoldenOutputFile(f)))
+        .map(f -> new GoldenInOutFilePair(f, getGoldenOutputFile(f)))
+        .filter(g -> g.outputFile.isFile())
         .collect(toImmutableList());
   }
 

--- a/java/jflex/migration/TestCase.java.vm
+++ b/java/jflex/migration/TestCase.java.vm
@@ -39,7 +39,6 @@ public class $testClassName {
         ImmutableList.of(
 #foreach ( $golden in $goldens )
             new GoldenInOutFilePair(
-                "$golden.Name",
                 new File(testRuntimeDir, "$golden.InputFileName"),
                 new File(testRuntimeDir, "$golden.OutputFileName"))
 #if( $foreach.hasNext ),#end

--- a/java/jflex/migration/TestCase.java.vm
+++ b/java/jflex/migration/TestCase.java.vm
@@ -31,29 +31,23 @@ import org.junit.Test;
 @Generated("jflex.migration.Migrator")
 public class $testClassName extends AbstractGoldenTest {
 
-  @Test
-  public void goldenTest() throws Exception {
+  private File testRuntimeDir = new File("javatests/$javaPackageDir");
 
-    // The .input / .output Golden files
-    File testRuntimeDir = new File("javatests/$javaPackageDir");
-    List<GoldenInOutFilePair> goldenFiles =
-        ImmutableList.of(
 #foreach ( $golden in $goldens )
-            new GoldenInOutFilePair(
-                new File(testRuntimeDir, "$golden.InputFileName"),
-                new File(testRuntimeDir, "$golden.OutputFileName"))
-#if( $foreach.hasNext ),#end
-        );
-#end
+  @Test
+  public void goldenTest$velocityCount() throws Exception {
+    GoldenInOutFilePair golden = new GoldenInOutFilePair(
+        new File(testRuntimeDir, "$golden.InputFileName"),
+        new File(testRuntimeDir, "$golden.OutputFileName"))
+    compareSystemOutWith(golden);
 
-    for (GoldenInOutFilePair golden : goldenFiles) {
-      compareSystemOutWith(golden);
+    // Scanner for $flexGrammar
+    $scannerClassName scanner = createScanner(golden.inputFile);
 
-      // Scanner for $flexGrammar
-      $scannerClassName scanner = createScanner(golden.inputFile);
-      scanner.yylex();
-    }
+    // Run the scanner
+    scanner.yylex();
   }
+#end
 
   private static $scannerClassName createScanner(File inputFile) throws FileNotFoundException {
     return new $scannerClassName(

--- a/java/jflex/migration/TestCase.java.vm
+++ b/java/jflex/migration/TestCase.java.vm
@@ -31,7 +31,7 @@ public class $testClassName extends AbstractGoldenTest {
   public void goldenTest$velocityCount() throws Exception {
     GoldenInOutFilePair golden = new GoldenInOutFilePair(
         new File(testRuntimeDir, "$golden.InputFileName"),
-        new File(testRuntimeDir, "$golden.OutputFileName"))
+        new File(testRuntimeDir, "$golden.OutputFileName"));
     compareSystemOutWith(golden);
 
     // Scanner for $flexGrammar

--- a/java/jflex/migration/TestCase.java.vm
+++ b/java/jflex/migration/TestCase.java.vm
@@ -14,6 +14,7 @@ import java.nio.charset.Charset;
 import java.util.List;
 import javax.annotation.Generated;
 import jflex.testing.diff.DiffOutputStream;
+import jflex.testing.testsuite.golden.AbstractGoldenTest;
 import jflex.testing.testsuite.golden.GoldenInOutFilePair;
 import org.junit.Test;
 
@@ -28,7 +29,7 @@ import org.junit.Test;
  */
 // TODO Migrate this test to proper unit tests.
 @Generated("jflex.migration.Migrator")
-public class $testClassName {
+public class $testClassName extends AbstractGoldenTest {
 
   @Test
   public void goldenTest() throws Exception {
@@ -46,18 +47,11 @@ public class $testClassName {
 #end
 
     for (GoldenInOutFilePair golden : goldenFiles) {
-      // in-memory output comparison
-      DiffOutputStream output =
-          new DiffOutputStream(Files.newReader(golden.outputFile, Charsets.UTF_8));
-      System.setOut(new PrintStream(output));
+      compareSystemOutWith(golden);
 
       // Scanner for $flexGrammar
       $scannerClassName scanner = createScanner(golden.inputFile);
       scanner.yylex();
-
-      assertWithMessage("All expected output has been printed on System.out")
-          .that(output.isCompleted())
-          .isTrue();
     }
   }
 

--- a/java/jflex/migration/TestCase.java.vm
+++ b/java/jflex/migration/TestCase.java.vm
@@ -2,18 +2,11 @@
 
 package $javaPackage;
 
-import static com.google.common.truth.Truth.assertWithMessage;
-
-import com.google.common.base.Charsets;
-import com.google.common.collect.ImmutableList;
 import com.google.common.io.Files;
 import java.io.File;
 import java.io.FileNotFoundException;
-import java.io.PrintStream;
 import java.nio.charset.Charset;
-import java.util.List;
 import javax.annotation.Generated;
-import jflex.testing.diff.DiffOutputStream;
 import jflex.testing.testsuite.golden.AbstractGoldenTest;
 import jflex.testing.testsuite.golden.GoldenInOutFilePair;
 import org.junit.Test;

--- a/java/jflex/migration/TestCase.java.vm
+++ b/java/jflex/migration/TestCase.java.vm
@@ -12,7 +12,9 @@ import jflex.testing.testsuite.golden.GoldenInOutFilePair;
 import org.junit.Test;
 
 /**
- * $testDescription
+ * Tests scanner generated from {@code $flexGrammar.Name}.
+ *
+ * <p>$testDescription
  *
  * <p>Note: This test was generated from {@code jflex-testsuite-maven-plugin} test cases. The test
  * relies on golden files for testing, expecting the scanner to output logs on the {@code
@@ -29,21 +31,18 @@ public class $testClassName extends AbstractGoldenTest {
 #foreach ( $golden in $goldens )
   @Test
   public void goldenTest$velocityCount() throws Exception {
-    GoldenInOutFilePair golden = new GoldenInOutFilePair(
-        new File(testRuntimeDir, "$golden.InputFileName"),
-        new File(testRuntimeDir, "$golden.OutputFileName"));
+    GoldenInOutFilePair golden =
+        new GoldenInOutFilePair(
+            new File(testRuntimeDir, "$golden.InputFileName"),
+            new File(testRuntimeDir, "$golden.OutputFileName"));
     compareSystemOutWith(golden);
 
-    // Scanner for $flexGrammar
     $scannerClassName scanner = createScanner(golden.inputFile);
-
-    // Run the scanner
     scanner.yylex();
   }
 #end
 
   private static $scannerClassName createScanner(File inputFile) throws FileNotFoundException {
-    return new $scannerClassName(
-        Files.newReader(inputFile, Charset.forName("UTF-8")));
+    return new $scannerClassName(Files.newReader(inputFile, Charset.forName("UTF-8")));
   }
 }

--- a/java/jflex/testing/testsuite/golden/AbstractGoldenTest.java
+++ b/java/jflex/testing/testsuite/golden/AbstractGoldenTest.java
@@ -1,0 +1,28 @@
+package jflex.testing.testsuite.golden;
+
+import static com.google.common.truth.Truth.assertWithMessage;
+
+import com.google.common.base.Charsets;
+import com.google.common.io.Files;
+import java.io.FileNotFoundException;
+import java.io.PrintStream;
+import jflex.testing.diff.DiffOutputStream;
+import org.junit.After;
+
+public class AbstractGoldenTest {
+
+  private DiffOutputStream output;
+
+  protected void compareSystemOutWith(GoldenInOutFilePair golden) throws FileNotFoundException {
+    // in-memory output comparison
+    output = new DiffOutputStream(Files.newReader(golden.outputFile, Charsets.UTF_8));
+    System.setOut(new PrintStream(output));
+  }
+
+  @After
+  public void checkOuputEntirelyGenerated() {
+    assertWithMessage("All expected output has been printed on System.out")
+        .that(output.isCompleted())
+        .isTrue();
+  }
+}

--- a/java/jflex/testing/testsuite/golden/BUILD
+++ b/java/jflex/testing/testsuite/golden/BUILD
@@ -3,6 +3,7 @@ java_library(
     testonly = True,
     srcs = ["AbstractGoldenTest.java"],
     visibility = ["//visibility:public"],
+    exports = [":model"],
     deps = [
         ":model",
         "//java/jflex/testing/diff",

--- a/java/jflex/testing/testsuite/golden/BUILD
+++ b/java/jflex/testing/testsuite/golden/BUILD
@@ -1,5 +1,19 @@
 java_library(
     name = "golden",
+    testonly = True,
+    srcs = ["AbstractGoldenTest.java"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":model",
+        "//java/jflex/testing/diff",
+        "//third_party/com/google/guava",
+        "//third_party/com/google/truth",
+        "//third_party/junit",
+    ],
+)
+
+java_library(
+    name = "model",
     srcs = ["GoldenInOutFilePair.java"],
     visibility = ["//visibility:public"],
     deps = [],

--- a/java/jflex/testing/testsuite/golden/GoldenInOutFilePair.java
+++ b/java/jflex/testing/testsuite/golden/GoldenInOutFilePair.java
@@ -4,18 +4,12 @@ import java.io.File;
 
 public class GoldenInOutFilePair {
 
-  public final String name;
   public final File inputFile;
   public final File outputFile;
 
-  public GoldenInOutFilePair(String name, File inputFile, File outputFile) {
-    this.name = name;
+  public GoldenInOutFilePair(File inputFile, File outputFile) {
     this.inputFile = inputFile;
     this.outputFile = outputFile;
-  }
-
-  public String getName() {
-    return name;
   }
 
   public String getInputFileName() {
@@ -27,6 +21,6 @@ public class GoldenInOutFilePair {
   }
 
   public String toString() {
-    return "Name:" + name;
+    return inputFile.getParent() + File.separator + inputFile.getName();
   }
 }

--- a/java/jflex/velocity/Velocity.java
+++ b/java/jflex/velocity/Velocity.java
@@ -41,6 +41,7 @@ public class Velocity {
 
   static {
     velocityRuntimeInstance.setProperty(RuntimeConstants.RUNTIME_REFERENCES_STRICT, "true");
+    velocityRuntimeInstance.setProperty("directive.foreach.counter.initial.value", 0);
   }
 
   public static void render(

--- a/javatests/jflex/testcase/caseless_jflex/BUILD
+++ b/javatests/jflex/testcase/caseless_jflex/BUILD
@@ -18,7 +18,7 @@ java_library(
         ":gen_caseless_scanner",
     ],
     deps = [
-        "//java/jflex/testing/testsuite/golden:model",
+        "//java/jflex/testing/testsuite/golden",
         "//third_party/com/google/guava",
     ],
 )
@@ -36,7 +36,6 @@ java_test(
         ":caseless_scanner",
         "//java/jflex/testing/diff",
         "//java/jflex/testing/testsuite/golden",
-        "//java/jflex/testing/testsuite/golden:model",
         "//third_party/com/google/guava",
         "//third_party/com/google/truth",
     ],

--- a/javatests/jflex/testcase/caseless_jflex/BUILD
+++ b/javatests/jflex/testcase/caseless_jflex/BUILD
@@ -18,7 +18,7 @@ java_library(
         ":gen_caseless_scanner",
     ],
     deps = [
-        "//java/jflex/testing/testsuite/golden",
+        "//java/jflex/testing/testsuite/golden:model",
         "//third_party/com/google/guava",
     ],
 )
@@ -36,6 +36,7 @@ java_test(
         ":caseless_scanner",
         "//java/jflex/testing/diff",
         "//java/jflex/testing/testsuite/golden",
+        "//java/jflex/testing/testsuite/golden:model",
         "//third_party/com/google/guava",
         "//third_party/com/google/truth",
     ],

--- a/javatests/jflex/testcase/caseless_jflex/CaselessGoldenTest.java
+++ b/javatests/jflex/testcase/caseless_jflex/CaselessGoldenTest.java
@@ -38,7 +38,6 @@ public class CaselessGoldenTest {
     List<GoldenInOutFilePair> goldenFiles =
         ImmutableList.of(
             new GoldenInOutFilePair(
-                "caseless",
                 new File(testRuntimeDir, "caseless-0.input"),
                 new File(testRuntimeDir, "caseless-0.output")));
 

--- a/javatests/jflex/testcase/caseless_jflex/CaselessGoldenTest.java
+++ b/javatests/jflex/testcase/caseless_jflex/CaselessGoldenTest.java
@@ -2,23 +2,19 @@
 
 package jflex.testcase.caseless_jflex;
 
-import static com.google.common.truth.Truth.assertWithMessage;
-
-import com.google.common.base.Charsets;
-import com.google.common.collect.ImmutableList;
 import com.google.common.io.Files;
 import java.io.File;
 import java.io.FileNotFoundException;
-import java.io.PrintStream;
 import java.nio.charset.Charset;
-import java.util.List;
 import javax.annotation.Generated;
-import jflex.testing.diff.DiffOutputStream;
+import jflex.testing.testsuite.golden.AbstractGoldenTest;
 import jflex.testing.testsuite.golden.GoldenInOutFilePair;
 import org.junit.Test;
 
 /**
- * tests %ignorecase with jflex semantics (only strings and chars are caseless)
+ * Tests scanner generated from {@code caseless.flex}.
+ *
+ * <p>tests %ignorecase with jflex semantics (only strings and chars are caseless)
  *
  * <p>Note: This test was generated from {@code jflex-testsuite-maven-plugin} test cases. The test
  * relies on golden files for testing, expecting the scanner to output logs on the {@code
@@ -28,34 +24,20 @@ import org.junit.Test;
  */
 // TODO Migrate this test to proper unit tests.
 @Generated("jflex.migration.Migrator")
-public class CaselessGoldenTest {
+public class CaselessGoldenTest extends AbstractGoldenTest {
+
+  private File testRuntimeDir = new File("javatests/jflex/testcase/caseless_jflex");
 
   @Test
-  public void goldenTest() throws Exception {
+  public void goldenTest0() throws Exception {
+    GoldenInOutFilePair golden =
+        new GoldenInOutFilePair(
+            new File(testRuntimeDir, "caseless-0.input"),
+            new File(testRuntimeDir, "caseless-0.output"));
+    compareSystemOutWith(golden);
 
-    // The .input / .output Golden files
-    File testRuntimeDir = new File("javatests/jflex/testcase/caseless_jflex");
-    List<GoldenInOutFilePair> goldenFiles =
-        ImmutableList.of(
-            new GoldenInOutFilePair(
-                new File(testRuntimeDir, "caseless-0.input"),
-                new File(testRuntimeDir, "caseless-0.output")));
-
-    for (GoldenInOutFilePair golden : goldenFiles) {
-      // in-memory output comparison
-      DiffOutputStream output =
-          new DiffOutputStream(Files.newReader(golden.outputFile, Charsets.UTF_8));
-      System.setOut(new PrintStream(output));
-
-      // Scanner for
-      // /Users/regis/Projects/jflex/testsuite/testcases/src/test/cases/caseless-jflex/caseless.flex
-      Caseless scanner = createScanner(golden.inputFile);
-      scanner.yylex();
-
-      assertWithMessage("All expected output has been printed on System.out")
-          .that(output.isCompleted())
-          .isTrue();
-    }
+    Caseless scanner = createScanner(golden.inputFile);
+    scanner.yylex();
   }
 
   private static Caseless createScanner(File inputFile) throws FileNotFoundException {


### PR DESCRIPTION
Improvements on #597 

* Order `data` before `deps` in `BUILD.vm` as required by bzl code style
* Improve logging of Migrator
* Refactor `TestCase.vm` to have one test method per golden, rather than looping over them all.
* Extract `AbstractGoldenTest` to improve code reuse
  java/jflex/testing/testsuite/golden/AbstractGoldenTest.java
* Remove unused name in GoldenInOutFilePair
* Regenerate testcase/caseless accordingly
