### PR TITLE
JflexTestRunner can now verify the output of JFlex itself

### DIFF
--- a/java/jflex/testing/testsuite/BUILD
+++ b/java/jflex/testing/testsuite/BUILD
@@ -8,6 +8,7 @@ java_library(
         "//java/jflex/testing/testsuite/annotations",
     ],
     deps = [
+        "//java/jflex/testing/diff",
         "//java/jflex/testing/testsuite/annotations",
         "//java/jflex/util/javac",
         "//jflex",

--- a/java/jflex/testing/testsuite/JFlexTestRunner.java
+++ b/java/jflex/testing/testsuite/JFlexTestRunner.java
@@ -29,9 +29,15 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.truth.Truth.assertWithMessage;
 import static org.junit.Assert.fail;
 
+import com.google.common.base.Charsets;
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
+import com.google.common.io.Files;
 import java.io.File;
+import java.io.FileNotFoundException;
+import jflex.core.Out;
 import jflex.generator.LexGenerator;
+import jflex.testing.diff.DiffOutputStream;
 import jflex.testing.testsuite.annotations.NoExceptionThrown;
 import jflex.testing.testsuite.annotations.TestSpec;
 import jflex.util.javac.CompilerException;
@@ -60,6 +66,17 @@ public class JFlexTestRunner extends BlockJUnit4ClassRunner {
 
   @Override
   public void run(RunNotifier notifier) {
+    if (!Strings.isNullOrEmpty(spec.sysout())) {
+      File sysoutFile = new File(spec.sysout());
+      try {
+        DiffOutputStream diffSysOut =
+            new DiffOutputStream(Files.newReader(sysoutFile, Charsets.UTF_8));
+        Out.setOutputStream(diffSysOut);
+      } catch (FileNotFoundException e) {
+        throw new AssertionError(
+            "The golden sysout was not found: " + sysoutFile.getAbsolutePath(), e);
+      }
+    }
     if (spec.generatorThrows() != NoExceptionThrown.class) {
       try {
         generateLexer(notifier);

--- a/java/jflex/testing/testsuite/annotations/TestSpec.java
+++ b/java/jflex/testing/testsuite/annotations/TestSpec.java
@@ -42,4 +42,7 @@ public @interface TestSpec {
    * expected.
    */
   Class<?> generatorThrowableCause() default NoExceptionThrown.class;
+
+  /** Golden file for JFlex's log (output stream). */
+  String sysout() default "";
 }

--- a/javatests/jflex/testcase/arr_return/ArrReturnTest.java
+++ b/javatests/jflex/testcase/arr_return/ArrReturnTest.java
@@ -31,7 +31,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 @RunWith(JFlexTestRunner.class)
-@TestSpec(lex = "javatests/jflex/testcase/arr_return/arr.flex")
+@TestSpec(
+    lex = "javatests/jflex/testcase/arr_return/arr.flex",
+    sysout = "javatests/jflex/testcase/arr_return/arr-flex.output")
 public class ArrReturnTest {
   @Test
   public void ok() {}

--- a/javatests/jflex/testcase/arr_return/BUILD
+++ b/javatests/jflex/testcase/arr_return/BUILD
@@ -3,5 +3,8 @@ load("//testsuite:testsuite.bzl", "jflex_testsuite")
 jflex_testsuite(
     name = "ArrReturnTest",
     srcs = ["ArrReturnTest.java"],
-    data = ["arr.flex"],
+    data = [
+        "arr.flex",
+        "arr-flex.output",
+    ],
 )

--- a/javatests/jflex/testcase/arr_return/arr-flex.output
+++ b/javatests/jflex/testcase/arr_return/arr-flex.output
@@ -1,0 +1,6 @@
+Reading "javatests/jflex/testcase/arr_return/arr.flex"
+Constructing NFA : 7 states in NFA
+Converting NFA to DFA : 
+....
+6 states before minimization, 5 states in minimized DFA
+Writing code to "javatests/jflex/testcase/arr_return/Arr.java"


### PR DESCRIPTION
The legacy test suite allows to test the JFlex logs.

I don't know how useful it is (sounds like a _change test_ to me), but this change adds this feature to the `JflexTestRunner`.
