### PR TITLE
Make zzScanError static

### DIFF
--- a/jflex/src/main/java/jflex/generator/Emitter.java
+++ b/jflex/src/main/java/jflex/generator/Emitter.java
@@ -198,7 +198,7 @@ public final class Emitter {
   }
 
   private void emitScanError() {
-    print("  private void zzScanError(int errorCode)");
+    print("  private static void zzScanError(int errorCode)");
 
     if (scanner.scanErrorException() != null) print(" throws " + scanner.scanErrorException());
 


### PR DESCRIPTION
It seems relatively safe to emit ``zzScanError` as static.

> bazel-out/darwin-fastbuild/bin/jflex/LexScan.java:2213: warning: [MethodCanBeStatic] A private method that does not reference the enclosing instance can be static
>   private void zzScanError(int errorCode) {
>   ^
>     (see https://errorprone.info/bugpattern/MethodCanBeStatic)
>   Did you mean 'private static void zzScanError(int errorCode) {'?