### PR TITLE
Do not run google-java-format on Unicode_x_y.java

### DIFF
--- a/scripts/test-java-format.sh
+++ b/scripts/test-java-format.sh
@@ -20,7 +20,7 @@ fi
 function gjf() {
   directory=$1
   logi "Checking $directory"
-  java -jar $TOOLSDIR/google-java-format-${VERSION_GJF}.jar --dry-run --set-exit-if-changed $(find $directory -name '*.java')
+  java -jar $TOOLSDIR/google-java-format-${VERSION_GJF}.jar --dry-run --set-exit-if-changed $(find $directory -type f \( -name '*.java' -and -not -name 'Unicode_*.java' \) )
 }
 
 if [[ ${TRAVIS} ]]; then


### PR DESCRIPTION
1. This files are generated code
2. They caus OOM errors, like
   > java.lang.OutOfMemoryError: Java heap space
   >	at com.google.common.collect.ImmutableList$Builder.<init>(ImmutableList.java:764)
   >	at com.google.common.collect.ImmutableRangeMap$Builder.build(ImmutableRangeMap.java:146)
   >	at com.google.googlejavaformat.java.JavaInput.<init>(JavaInput.java:285)
   >	at com.google.googlejavaformat.java.Formatter.getFormatReplacements(Formatter.java:247)
   >	at com.google.googlejavaformat.java.Formatter.formatSource(Formatter.java:234)
   >	at com.google.googlejavaformat.java.FormatFileCallable.call(FormatFileCallable.java:45)
   >	at com.google.googlejavaformat.java.FormatFileCallable.call(FormatFileCallable.java:26)
   >	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
   >	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
   >	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
   >	at java.lang.Thread.run(Thread.java:748)
   
   https://cirrus-ci.com/task/5188755115212800