### PR TITLE
Simplify .bazelrc

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,7 +1,8 @@
 test --test_output=errors
-test --combined_report=lcov
-# https://github.com/bazelbuild/bazel/issues/6450
-test --coverage_report_generator="@bazel_tools//tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator:Main"
+
+# https://github.com/ProdriveTechnologies/bazel-pandoc/issues/6
+# test --combined_report=lcov
+# test --coverage_report_generator="@bazel_tools//tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator:Main"
 
 # http://errorprone.info/bugpatterns
 # To avoid bugs in the code

--- a/.bazelrc
+++ b/.bazelrc
@@ -1,9 +1,3 @@
-# This incompatible change was introduced in Bazel 0.26
-# https://github.com/bazelbuild/bazel/issues/5817
-# bazel_pandoc needs to update 
-# https://github.com/ProdriveTechnologies/bazel-pandoc/issues/6
-build --incompatible_depset_union=false
-
 test --test_output=errors
 test --combined_report=lcov
 # https://github.com/bazelbuild/bazel/issues/6450

--- a/.ci.bazelrc
+++ b/.ci.bazelrc
@@ -1,9 +1,5 @@
 import %workspace%/.bazelrc
 
-# This is from Bazel's former travis setup, to avoid blowing up the RAM usage.
-startup --host_jvm_args=-Xms2000m
-startup --host_jvm_args=-Xmx3000m
-
 # This is so we understand failures better
 build --verbose_failures
 test  --test_output=errors

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -20,11 +20,20 @@ jflex_deps()
 
 # pandoc used to build the documentatoin
 
-http_archive(
+#http_archive(
+#    name = "bazel_pandoc",
+#    sha256 = "47ad1f08db3e6c8cc104931c11e099fd0603c174400b9cc852e2481abe08db24",
+#    strip_prefix = "bazel-pandoc-0.2",
+#    url = "https://github.com/ProdriveTechnologies/bazel-pandoc/archive/v0.2.tar.gz",
+#)
+
+# The unionset incompatible change was introduced in Bazel 0.26
+# bazel_pandoc needs to update
+# https://github.com/ProdriveTechnologies/bazel-pandoc/issues/6
+git_repository(
     name = "bazel_pandoc",
-    sha256 = "47ad1f08db3e6c8cc104931c11e099fd0603c174400b9cc852e2481abe08db24",
-    strip_prefix = "bazel-pandoc-0.2",
-    url = "https://github.com/ProdriveTechnologies/bazel-pandoc/archive/v0.2.tar.gz",
+    commit = "7d87bb1463835bfea8438a5dae8f536d1857c97f",
+    remote = "https://github.com/ProdriveTechnologies/bazel-pandoc.git",
 )
 
 load("@bazel_pandoc//:repositories.bzl", "pandoc_repositories")

--- a/scripts/test-examples.sh
+++ b/scripts/test-examples.sh
@@ -17,7 +17,7 @@ fi
 
 which ant
 if [[ $? -eq 0 ]]; then
-  ANT=make
+  ANT=ant
 else
   ANT=echo
 fi


### PR DESCRIPTION
* https://github.com/ProdriveTechnologies/bazel-pandoc/issues/6 is fixed and we use bazel_pandoc-02 No need to work around with incompatiple_depset_union.
* test coverage aggregation worked locally, but never worked on CI. Forget about it. #608 uses partial reports