### PR TITLE
Fix of pseudo-format in aggregated-sources

### DIFF
--- a/scripts/preparare-deploy-source-code.sh
+++ b/scripts/preparare-deploy-source-code.sh
@@ -76,8 +76,8 @@ update_source() {
 # N.B. TRAVIS_BRANCH is the name of the branch targeted by the pull request (if PR)
 logi "On branch ${TRAVIS_PULL_REQUEST_SLUG}:${TRAVIS_PULL_REQUEST_BRANCH} → ${TRAVIS_BRANCH}"
 
-gittitle=$(git log -1 --pretty=format:oneline)
-gitlog=$(git log -1 --pretty=format:fuller)
+gittitle=$(git log -1 --pretty=format:'%h %s')
+gitlog=$(git log -1 --pretty=fuller)
 git_clone
 update_source "$gittitle" "$gitlog"
 


### PR DESCRIPTION
Follow-up fix of #613.
"oneline" and "fuller" are pretty aliases. "format:" is not what we want in this case.