### PR TITLE
Update in Velocity engine directive.foreach.counter.initial.value

### DIFF
--- a/java/jflex/migration/TestCase.java.vm
+++ b/java/jflex/migration/TestCase.java.vm
@@ -35,7 +35,7 @@ public class $testClassName extends AbstractGoldenTest {
 
 #foreach ( $golden in $goldens )
   @Test
-  public void goldenTest$velocityCount() throws Exception {
+  public void goldenTest${foreach.index}() throws Exception {
     GoldenInOutFilePair golden =
         new GoldenInOutFilePair(
             new File(testRuntimeDir, "$golden.InputFileName"),

--- a/java/jflex/velocity/Velocity.java
+++ b/java/jflex/velocity/Velocity.java
@@ -41,7 +41,6 @@ public class Velocity {
 
   static {
     velocityRuntimeInstance.setProperty(RuntimeConstants.RUNTIME_REFERENCES_STRICT, "true");
-    velocityRuntimeInstance.setProperty("directive.foreach.counter.initial.value", 0);
   }
 
   public static void render(


### PR DESCRIPTION
WARNING: The directive.foreach.counter.initial.value property has been deprecated. It will be removed (along with $velocityCount itself) in Velocity 2.0.  Instead, please use $foreach.index to access the 0-based loop index and $foreach.count to access the 1-based loop counter.