### PR TITLE
Improve performance of RepeatedContentReader

### DIFF
--- a/javatests/jflex/testcase/large_input/LargeInputTest.java
+++ b/javatests/jflex/testcase/large_input/LargeInputTest.java
@@ -4,7 +4,6 @@ import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
 
 import com.google.common.io.CharSource;
-import java.io.IOException;
 import java.io.Reader;
 import org.junit.Test;
 
@@ -28,7 +27,11 @@ public class LargeInputTest {
         .isGreaterThan((long) Integer.MAX_VALUE + 1L);
     Reader largeContentReader = new RepeatContentReader(size, content);
     LargeInputScanner scanner = createScanner(largeContentReader);
-    readUntilEof(scanner);
+    assertThat(scanner.yylex()).isEqualTo(State.BEFORE_2GB);
+    while (scanner.yylex() == State.BEFORE_2GB) {}
+    assertThat(scanner.yylex()).isEqualTo(State.AFTER_2GB);
+    assertThat(scanner.yylex()).isEqualTo(State.AFTER_2GB);
+    assertThat(scanner.yylex()).isEqualTo(State.END_OF_FILE);
   }
 
   @Test
@@ -50,11 +53,6 @@ public class LargeInputTest {
     assertThat(scanner.yylex()).isEqualTo(State.BEFORE_2GB);
     assertThat(scanner.yylex()).isEqualTo(State.BEFORE_2GB);
     assertThat(scanner.yylex()).isEqualTo(State.END_OF_FILE);
-  }
-
-  @SuppressWarnings("StatementWithEmptyBody")
-  private static void readUntilEof(LargeInputScanner scanner) throws IOException {
-    while (scanner.yylex() != State.END_OF_FILE) {}
   }
 
   private static LargeInputScanner createScanner(Reader reader) {

--- a/javatests/jflex/testcase/large_input/RepeatContentReader.java
+++ b/javatests/jflex/testcase/large_input/RepeatContentReader.java
@@ -9,7 +9,7 @@ import java.io.Reader;
 public class RepeatContentReader extends Reader {
 
   /** Size of the precomputed buffer with the repeated content. */
-  private static final int PREPARED_BUFFER_SIZE = 64 * 1024;
+  private static final int PREPARED_BUFFER_SIZE = 256 * 1024;
 
   /** The size of the content that this reader will provide. */
   private final long size;

--- a/javatests/jflex/testcase/large_input/RepeatContentReader.java
+++ b/javatests/jflex/testcase/large_input/RepeatContentReader.java
@@ -62,15 +62,15 @@ public class RepeatContentReader extends Reader {
       // content is always small.
       return givenContent;
     }
-    // wantedSize > content.size(): The reader will loop over then content.
+    // wantedSize > content.size(): The reader will loop over the content.
     if (givenContent.length >= PREPARED_BUFFER_SIZE) {
       // The given content is large enough. Nothing to do.
       return givenContent;
     }
-    // To maximize use of the buffer, we already prepare a repeated content of PREPARED_BUFFER_SIZE.
+    // To maximize use of the buffer, we already prepare a repeated content of ~PREPARED_BUFFER_SIZE
     int size = PREPARED_BUFFER_SIZE / givenContent.length * givenContent.length;
     if (size > wantedSize) {
-      // But we dont't need so much if we read less.
+      // But we don't need so much if we read less.
       size = (int) (wantedSize / givenContent.length + 1) * givenContent.length;
     }
     char[] myContent = new char[size];


### PR DESCRIPTION
Increase internal buffer size to 256kB in order improve performance.
Follow-up of #603 