### PR TITLE
Won't bazelify testcase/encoding

### DIFF
--- a/javatests/jflex/testcase/README.md
+++ b/javatests/jflex/testcase/README.md
@@ -11,3 +11,12 @@ To run all regression tests:
 There are only a few tests, as their migration from Bazel is work in progress.
 
 See [Migration instructions](https://github.com/jflex-de/jflex/wiki/Migration-to-Bazel#migrate-a-golden-test).
+
+### Not migrated
+
+- **encoding**.
+  Bazel makes it hard to
+  [change the encoding used by javac](https://stackoverflow.com/a/43472003/94363).
+  It's UTF-8 by default.
+  And the use of `--encoding` changes both the input `.flex` and the generated `.java`
+  files.

--- a/testsuite/testcases/src/test/cases/encoding/README.md
+++ b/testsuite/testcases/src/test/cases/encoding/README.md
@@ -1,0 +1,4 @@
+NOT Migrated to Bazel
+
+Changing the encoding is not something easy to do.
+https://stackoverflow.com/a/43472003/94363


### PR DESCRIPTION
Bazel doesn't allow to easily change the encoding of Java sources [ref](https://stackoverflow.com/a/43472003/94363).
And `—encoding` option applies to both source `.flex` and generated `.java`.
