### PR TITLE
Make LargeInputTest run much faster by faking the scanner position

### DIFF
--- a/javatests/jflex/testcase/large_input/BUILD
+++ b/javatests/jflex/testcase/large_input/BUILD
@@ -38,6 +38,7 @@ jflex(
 
 java_library(
     name = "repeat_content_reader",
+    testonly = True,
     srcs = ["RepeatContentReader.java"],
     deps = [
         "//third_party/com/google/guava",

--- a/javatests/jflex/testcase/large_input/LargeInputTest.java
+++ b/javatests/jflex/testcase/large_input/LargeInputTest.java
@@ -1,7 +1,6 @@
 package jflex.testcase.large_input;
 
 import static com.google.common.truth.Truth.assertThat;
-import static com.google.common.truth.Truth.assertWithMessage;
 
 import com.google.common.io.CharSource;
 import java.io.Reader;

--- a/javatests/jflex/testcase/large_input/LargeInputTest.java
+++ b/javatests/jflex/testcase/large_input/LargeInputTest.java
@@ -21,15 +21,14 @@ public class LargeInputTest {
   @Test
   public void consumeLargeInput() throws Exception {
     final String content = "One every character the `yychar` is incremented, but don't overflow!\n";
-    long size = (long) Integer.MAX_VALUE + 3 * (long) content.length(); // a few more
-    assertWithMessage("Tests an input content larger than MAX_INT (2^32-1)")
-        .that(size)
-        .isGreaterThan((long) Integer.MAX_VALUE + 1L);
+    long size = 4 * (long) content.length();
     Reader largeContentReader = new RepeatContentReader(size, content);
     LargeInputScanner scanner = createScanner(largeContentReader);
+    // Pretend we move close to MAX_INT
+    scanner.fakeRead(Integer.MAX_VALUE - 2 * content.length());
     assertThat(scanner.yylex()).isEqualTo(State.BEFORE_2GB);
-    while (scanner.yylex() == State.BEFORE_2GB) {}
-    assertThat(scanner.yylex()).isEqualTo(State.AFTER_2GB);
+    assertThat(scanner.yylex()).isEqualTo(State.BEFORE_2GB);
+    assertThat(scanner.yylex()).isEqualTo(State.BEFORE_2GB);
     assertThat(scanner.yylex()).isEqualTo(State.AFTER_2GB);
     assertThat(scanner.yylex()).isEqualTo(State.END_OF_FILE);
   }

--- a/javatests/jflex/testcase/large_input/large_input.flex
+++ b/javatests/jflex/testcase/large_input/large_input.flex
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.io.Reader;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.ZipException;
+
 %%
 
 %public
@@ -17,6 +18,12 @@ import java.util.zip.ZipException;
 %char
 %unicode
 %type State
+
+%{
+  void fakeRead(int nbCharacters) {
+    yychar += nbCharacters;
+  }
+%}
 
 %%
 


### PR DESCRIPTION
Introduce a fakeRead() that changes `yychar` so that we can fakely jump to yychar just before Integer.MAX_VALUE and make the test run in a snap.

Follow-up of #603 and #605