### PR TITLE
remove the MainFrame.stop button that called deprecated Thread.stop()

### DIFF
--- a/jflex/src/main/java/jflex/gui/MainFrame.java
+++ b/jflex/src/main/java/jflex/gui/MainFrame.java
@@ -38,7 +38,6 @@ public final class MainFrame extends Frame implements Handles {
 
   private Button quit;
   private Button generate;
-  private Button stop;
   private Button specChoose;
   private Button dirChoose;
 
@@ -73,7 +72,6 @@ public final class MainFrame extends Frame implements Handles {
     generate = new Button("Generate");
     quit = new Button("Quit");
     Button options = new Button("Options");
-    stop = new Button("Stop");
     dirChoose = new Button("Browse");
     dir = new TextField(10);
     specChoose = new Button("Browse");
@@ -105,13 +103,6 @@ public final class MainFrame extends Frame implements Handles {
         new ActionListener() {
           public void actionPerformed(ActionEvent e) {
             quit();
-          }
-        });
-
-    stop.addActionListener(
-        new ActionListener() {
-          public void actionPerformed(ActionEvent e) {
-            stop();
           }
         });
 
@@ -165,7 +156,6 @@ public final class MainFrame extends Frame implements Handles {
     north.add(4, 0, quit);
     north.add(4, 1, generate);
     north.add(4, 2, options);
-    north.add(4, 3, stop);
 
     north.add(0, 0, BOTTOM, new Label("Lexical specification:"));
     north.add(0, 1, 2, 1, spec);
@@ -205,7 +195,6 @@ public final class MainFrame extends Frame implements Handles {
   }
 
   private void setEnabledAll(boolean generating) {
-    stop.setEnabled(generating);
     quit.setEnabled(!generating);
     generate.setEnabled(!generating);
     dirChoose.setEnabled(!generating);
@@ -234,17 +223,6 @@ public final class MainFrame extends Frame implements Handles {
 
     if (success) messages.append(Out.NL + "Generation finished successfully." + Out.NL);
     else messages.append(Out.NL + "Generation aborted." + Out.NL);
-  }
-
-  private void stop() {
-    if (thread != null) {
-      /* stop ok here despite deprecation (?)
-      I don't know any good way to abort generation without changing the
-      generator code */
-      thread.stop();
-      thread = null;
-    }
-    generationFinished(false);
   }
 
   private void quit() {


### PR DESCRIPTION
The time it takes to run JFlex even on large specs is now small enough
to not need this button any more.

It is unlikely that the GUI is used much these days in any case.