### PR TITLE
do not create char classes for NL characters for atBOL matching

### DIFF
--- a/javatests/jflex/testcase/bol/BUILD
+++ b/javatests/jflex/testcase/bol/BUILD
@@ -7,11 +7,19 @@ jflex(
     outputs = ["BolScanner.java"],
 )
 
+jflex(
+    name = "gen_bol2_scanner",
+    srcs = ["bol2.flex"],
+    jflex_bin = "//jflex:jflex_bin",
+    outputs = ["Bol2Scanner.java"],
+)
+
 java_test(
     name = "BolTest",
     srcs = [
         "BolTest.java",
         "State.java",
+        ":gen_bol2_scanner",
         ":gen_bol_scanner",
     ],
     deps = [

--- a/javatests/jflex/testcase/bol/BolTest.java
+++ b/javatests/jflex/testcase/bol/BolTest.java
@@ -10,16 +10,25 @@ import org.junit.Test;
 
 /** Tests BOL and EOL operators. */
 public class BolTest {
+  // standard BOL and EOL tests
   BolScanner scanner;
+  // test BOL in absence of char class for NL characters
+  Bol2Scanner scanner2;
 
   @Before
   public void testMustInitializeScanner() {
     scanner = null;
+    scanner2 = null;
   }
 
   @After
   public void end() throws Exception {
-    assertThat(scanner.yylex()).isEqualTo(State.END_OF_FILE);
+    if (scanner != null) {
+      assertThat(scanner.yylex()).isEqualTo(State.END_OF_FILE);
+    }
+    if (scanner2 != null) {
+      assertThat(scanner2.yylex()).isEqualTo(State.END_OF_FILE);
+    }
   }
 
   @Test
@@ -33,6 +42,30 @@ public class BolTest {
     scanner = createScanner("hello\n");
     assertThat(scanner.yylex()).isEqualTo(State.HELLO_AT_BOL_AND_EOL);
     assertThat(scanner.yylex()).isEqualTo(State.LINE_FEED);
+  }
+
+  @Test
+  public void bolAndEol2() throws Exception {
+    scanner = createScanner("hello\r\n");
+    assertThat(scanner.yylex()).isEqualTo(State.HELLO_AT_BOL_AND_EOL);
+    assertThat(scanner.yylex()).isEqualTo(State.OTHER);
+    assertThat(scanner.yylex()).isEqualTo(State.LINE_FEED);
+  }
+
+  @Test
+  public void bolAndEol3() throws Exception {
+    scanner = createScanner("\nhello\r\n");
+    assertThat(scanner.yylex()).isEqualTo(State.LINE_FEED);
+    assertThat(scanner.yylex()).isEqualTo(State.HELLO_AT_BOL_AND_EOL);
+    assertThat(scanner.yylex()).isEqualTo(State.OTHER);
+    assertThat(scanner.yylex()).isEqualTo(State.LINE_FEED);
+  }
+
+  @Test
+  public void bolAndEof() throws Exception {
+    // EOF does not count as EOL. Should it?
+    scanner = createScanner("hello");
+    assertThat(scanner.yylex()).isEqualTo(State.HELLO_AT_BOL);
   }
 
   @Test
@@ -79,7 +112,35 @@ public class BolTest {
     assertThat(scanner.yylex()).isEqualTo(State.LINE_FEED);
   }
 
+  @Test
+  public void bolNoNLCCL() throws Exception {
+    scanner2 = createScanner2("hello");
+    assertThat(scanner2.yylex()).isEqualTo(State.HELLO_AT_BOL);
+  }
+
+  @Test
+  public void bolNoNLCCL2() throws Exception {
+    scanner2 = createScanner2("hello\n");
+    assertThat(scanner2.yylex()).isEqualTo(State.HELLO_AT_BOL);
+    assertThat(scanner2.yylex()).isEqualTo(State.OTHER);
+  }
+
+  @Test
+  public void noBolNoNLCCL() throws Exception {
+    scanner2 = createScanner2("\n  hello  ");
+    assertThat(scanner2.yylex()).isEqualTo(State.OTHER);
+    assertThat(scanner2.yylex()).isEqualTo(State.OTHER);
+    assertThat(scanner2.yylex()).isEqualTo(State.OTHER);
+    assertThat(scanner2.yylex()).isEqualTo(State.HELLO_SIMPLY);
+    assertThat(scanner2.yylex()).isEqualTo(State.OTHER);
+    assertThat(scanner2.yylex()).isEqualTo(State.OTHER);
+  }
+
   private static BolScanner createScanner(final String content) throws IOException {
     return new BolScanner(CharSource.wrap(content).openStream());
+  }
+
+  private static Bol2Scanner createScanner2(final String content) throws IOException {
+    return new Bol2Scanner(CharSource.wrap(content).openStream());
   }
 }

--- a/javatests/jflex/testcase/bol/State.java
+++ b/javatests/jflex/testcase/bol/State.java
@@ -6,7 +6,6 @@ public enum State {
   HELLO_AT_BOL,
   HELLO_AT_EOL,
   HELLO_SIMPLY,
-  CARRIAGE_RETURN,
   LINE_FEED,
   SPACE,
   OTHER,

--- a/javatests/jflex/testcase/bol/bol.flex
+++ b/javatests/jflex/testcase/bol/bol.flex
@@ -24,10 +24,9 @@ package jflex.testcase.bol;
 "hello"$   { return State.HELLO_AT_EOL; }
 "hello"    { return State.HELLO_SIMPLY; }
 
-\r         { return State.CARRIAGE_RETURN; }
 \n         { return State.LINE_FEED; }
 
 " "        { return State.SPACE; }
-.          { return State.OTHER; }
+[^]        { return State.OTHER; }
 
 <<EOF>>    { return State.END_OF_FILE; }

--- a/javatests/jflex/testcase/bol/bol2.flex
+++ b/javatests/jflex/testcase/bol/bol2.flex
@@ -1,0 +1,19 @@
+package jflex.testcase.bol;
+
+%%
+
+%public
+%class Bol2Scanner
+%type State
+%debug
+
+%unicode
+
+%%
+
+^"hello"   { return State.HELLO_AT_BOL; }
+"hello"    { return State.HELLO_SIMPLY; }
+
+[^]        { return State.OTHER; }
+
+<<EOF>>    { return State.END_OF_FILE; }

--- a/jflex/src/main/cup/LexParse.cup
+++ b/jflex/src/main/cup/LexParse.cup
@@ -596,11 +596,7 @@ states        ::=  IDENT:id COMMA states:list
                 ;
 
 hatOPT        ::=  HAT
-                   {:
-                      // assumption: newline chars have no uppercase variant
-                      charClasses.makeClass("\n\r\u000B\u000C\u0085\u2028\u2029", false);
-                      RESULT = true;
-                   :}
+                   {: RESULT = true; :}
                 |  /* empty */
                    {: RESULT = false; :}
                 ;

--- a/testsuite/testcases/src/test/cases/bol/.gitignore
+++ b/testsuite/testcases/src/test/cases/bol/.gitignore
@@ -1,1 +1,2 @@
 Bol.java
+Bol2.java

--- a/testsuite/testcases/src/test/cases/bol/bol-0.output
+++ b/testsuite/testcases/src/test/cases/bol/bol-0.output
@@ -2,87 +2,90 @@ line: 1 col: 1 char: 0 match: --hello--
 action [19] { System.out.println("hello at BOL and EOL"); }
 hello at BOL and EOL
 line: 1 col: 6 char: 5 match: --\u000A--
-action [25] { System.out.println("\\n"); }
+action [24] { System.out.println("\\n"); }
 \n
 line: 2 col: 1 char: 6 match: -- --
-action [27] { System.out.println( "\" \"" ); }
+action [26] { System.out.println( "\" \"" ); }
 " "
 line: 2 col: 2 char: 7 match: -- --
-action [27] { System.out.println( "\" \"" ); }
+action [26] { System.out.println( "\" \"" ); }
 " "
 line: 2 col: 3 char: 8 match: --hello--
 action [21] { System.out.println("hello at EOL"); }
 hello at EOL
 line: 2 col: 8 char: 13 match: --\u000A--
-action [25] { System.out.println("\\n"); }
+action [24] { System.out.println("\\n"); }
 \n
 line: 3 col: 1 char: 14 match: -- --
-action [27] { System.out.println( "\" \"" ); }
+action [26] { System.out.println( "\" \"" ); }
 " "
 line: 3 col: 2 char: 15 match: -- --
-action [27] { System.out.println( "\" \"" ); }
+action [26] { System.out.println( "\" \"" ); }
 " "
 line: 3 col: 3 char: 16 match: --hello--
 action [22] { System.out.println("just hello"); }
 just hello
 line: 3 col: 8 char: 21 match: -- --
-action [27] { System.out.println( "\" \"" ); }
+action [26] { System.out.println( "\" \"" ); }
 " "
 line: 3 col: 9 char: 22 match: -- --
-action [27] { System.out.println( "\" \"" ); }
+action [26] { System.out.println( "\" \"" ); }
 " "
 line: 3 col: 10 char: 23 match: --\u000A--
-action [25] { System.out.println("\\n"); }
+action [24] { System.out.println("\\n"); }
 \n
 line: 4 col: 1 char: 24 match: --hello--
 action [20] { System.out.println("hello at BOL"); }
 hello at BOL
 line: 4 col: 6 char: 29 match: -- --
-action [27] { System.out.println( "\" \"" ); }
+action [26] { System.out.println( "\" \"" ); }
 " "
 line: 4 col: 7 char: 30 match: --\u000A--
-action [25] { System.out.println("\\n"); }
+action [24] { System.out.println("\\n"); }
 \n
 line: 5 col: 1 char: 31 match: -- --
-action [27] { System.out.println( "\" \"" ); }
+action [26] { System.out.println( "\" \"" ); }
 " "
 line: 5 col: 2 char: 32 match: -- --
-action [27] { System.out.println( "\" \"" ); }
+action [26] { System.out.println( "\" \"" ); }
 " "
 line: 5 col: 3 char: 33 match: --hello--
 action [21] { System.out.println("hello at EOL"); }
 hello at EOL
 line: 5 col: 8 char: 38 match: --\u000A--
-action [25] { System.out.println("\\n"); }
+action [24] { System.out.println("\\n"); }
 \n
 line: 6 col: 1 char: 39 match: --hello--
 action [20] { System.out.println("hello at BOL"); }
 hello at BOL
 line: 6 col: 6 char: 44 match: -- --
-action [27] { System.out.println( "\" \"" ); }
+action [26] { System.out.println( "\" \"" ); }
 " "
 line: 6 col: 7 char: 45 match: --\u000A--
-action [25] { System.out.println("\\n"); }
+action [24] { System.out.println("\\n"); }
 \n
 line: 7 col: 1 char: 46 match: -- --
-action [27] { System.out.println( "\" \"" ); }
+action [26] { System.out.println( "\" \"" ); }
 " "
 line: 7 col: 2 char: 47 match: --\u000A--
-action [25] { System.out.println("\\n"); }
+action [24] { System.out.println("\\n"); }
 \n
 line: 8 col: 1 char: 48 match: --s--
-action [28] { System.out.println( yytext() ); }
+action [27] { System.out.println( yytext() ); }
 s
 line: 8 col: 2 char: 49 match: --d--
-action [28] { System.out.println( yytext() ); }
+action [27] { System.out.println( yytext() ); }
 d
 line: 8 col: 3 char: 50 match: --f--
-action [28] { System.out.println( yytext() ); }
+action [27] { System.out.println( yytext() ); }
 f
 line: 8 col: 4 char: 51 match: --a--
-action [28] { System.out.println( yytext() ); }
+action [27] { System.out.println( yytext() ); }
 a
 line: 8 col: 5 char: 52 match: --\u000A--
-action [25] { System.out.println("\\n"); }
+action [24] { System.out.println("\\n"); }
 \n
+line: 9 col: 1 char: 53 match: --hello--
+action [20] { System.out.println("hello at BOL"); }
+hello at BOL
 -1

--- a/testsuite/testcases/src/test/cases/bol/bol-flex.output
+++ b/testsuite/testcases/src/test/cases/bol/bol-flex.output
@@ -1,63 +1,49 @@
 Reading "src/test/cases/bol/bol.flex"
 CharClasses:
 class 0:
-{ [0-9][14-31]['!'-'d']['f'-'g']['i'-'k']['m'-'n']['p'-132][134-8231][8234-55295][57344-1114111] }
+{ [0-9][14-31]['!'-'d']['f'-'g']['i'-'k']['m'-'n']['p'-132][134-8231][8234-1114111] }
 class 1:
 { [10] }
 class 2:
-{ [11] }
+{ [11-12][133][8232-8233] }
 class 3:
-{ [12] }
-class 4:
 { [13] }
-class 5:
+class 4:
 { [' '] }
-class 6:
+class 5:
 { ['e'] }
-class 7:
+class 6:
 { ['h'] }
-class 8:
+class 7:
 { ['l'] }
-class 9:
+class 8:
 { ['o'] }
-class 10:
-{ [133] }
-class 11:
-{ [8232] }
-class 12:
-{ [8233] }
-class 13:
-{ [55296-57343] }
 
 Constructing NFA : NFA is
 State 0
-  with epsilon in {22, 36, 42, 44, 46, 48}
+  with epsilon in {22, 36, 42, 44, 46}
 State 1
-  with epsilon in {2, 16, 22, 36, 42, 44, 46, 48}
+  with epsilon in {2, 16, 22, 36, 42, 44, 46}
 State 2
-  with 7 in {3}
+  with 6 in {3}
 State 3
-  with 6 in {4}
+  with 5 in {4}
 State 4
-  with 8 in {5}
+  with 7 in {5}
 State 5
-  with 8 in {6}
+  with 7 in {6}
 State 6
-  with 9 in {7}
+  with 8 in {7}
 State 7
   with epsilon in {14}
 State 8
   with 1 in {9}
   with 2 in {9}
   with 3 in {9}
-  with 4 in {9}
-  with 10 in {9}
-  with 11 in {9}
-  with 12 in {9}
 State 9
   with epsilon in {15}
 State 10
-  with 4 in {11}
+  with 3 in {11}
 State 11
   with epsilon in {12}
 State 12
@@ -68,40 +54,36 @@ State 14
   with epsilon in {8, 10}
 State[FINAL, FIXED_BASE] 15
 State 16
-  with 7 in {17}
+  with 6 in {17}
 State 17
-  with 6 in {18}
+  with 5 in {18}
 State 18
-  with 8 in {19}
+  with 7 in {19}
 State 19
-  with 8 in {20}
+  with 7 in {20}
 State 20
-  with 9 in {21}
+  with 8 in {21}
 State[FINAL] 21
 State 22
-  with 7 in {23}
+  with 6 in {23}
 State 23
-  with 6 in {24}
+  with 5 in {24}
 State 24
-  with 8 in {25}
+  with 7 in {25}
 State 25
-  with 8 in {26}
+  with 7 in {26}
 State 26
-  with 9 in {27}
+  with 8 in {27}
 State 27
   with epsilon in {34}
 State 28
   with 1 in {29}
   with 2 in {29}
   with 3 in {29}
-  with 4 in {29}
-  with 10 in {29}
-  with 11 in {29}
-  with 12 in {29}
 State 29
   with epsilon in {35}
 State 30
-  with 4 in {31}
+  with 3 in {31}
 State 31
   with epsilon in {32}
 State 32
@@ -112,164 +94,150 @@ State 34
   with epsilon in {28, 30}
 State[FINAL, FIXED_BASE] 35
 State 36
-  with 7 in {37}
+  with 6 in {37}
 State 37
-  with 6 in {38}
+  with 5 in {38}
 State 38
-  with 8 in {39}
+  with 7 in {39}
 State 39
-  with 8 in {40}
+  with 7 in {40}
 State 40
-  with 9 in {41}
+  with 8 in {41}
 State[FINAL] 41
 State 42
-  with 4 in {43}
+  with 1 in {43}
 State[FINAL] 43
 State 44
-  with 1 in {45}
+  with 4 in {45}
 State[FINAL] 45
 State 46
+  with 0 in {47}
+  with 1 in {47}
+  with 2 in {47}
+  with 3 in {47}
+  with 4 in {47}
   with 5 in {47}
+  with 6 in {47}
+  with 7 in {47}
+  with 8 in {47}
 State[FINAL] 47
-State 48
-  with 0 in {49}
-  with 5 in {49}
-  with 6 in {49}
-  with 7 in {49}
-  with 8 in {49}
-  with 9 in {49}
-State[FINAL] 49
 
 
-50 states in NFA
+48 states in NFA
 Converting NFA to DFA : 
-....................
+...................
 DFA is
 State 0:
   with 0 in 2
   with 1 in 3
+  with 2 in 2
+  with 3 in 2
   with 4 in 4
-  with 5 in 5
-  with 6 in 2
-  with 7 in 6
+  with 5 in 2
+  with 6 in 5
+  with 7 in 2
   with 8 in 2
-  with 9 in 2
 State 1:
   with 0 in 2
   with 1 in 3
+  with 2 in 2
+  with 3 in 2
   with 4 in 4
-  with 5 in 5
-  with 6 in 2
-  with 7 in 7
+  with 5 in 2
+  with 6 in 6
+  with 7 in 2
   with 8 in 2
-  with 9 in 2
 State [FINAL] 2:
 State [FINAL] 3:
 State [FINAL] 4:
 State [FINAL] 5:
+  with 5 in 7
 State [FINAL] 6:
-  with 6 in 8
-State [FINAL] 7:
-  with 6 in 9
+  with 5 in 8
+State 7:
+  with 7 in 9
 State 8:
-  with 8 in 10
+  with 7 in 10
 State 9:
-  with 8 in 11
+  with 7 in 11
 State 10:
-  with 8 in 12
+  with 7 in 12
 State 11:
   with 8 in 13
 State 12:
-  with 9 in 14
-State 13:
-  with 9 in 15
-State [FINAL] 14:
-  with 1 in 16
-  with 2 in 16
+  with 8 in 14
+State [FINAL] 13:
+  with 1 in 15
+  with 2 in 15
   with 3 in 16
-  with 4 in 17
-  with 10 in 16
-  with 11 in 16
-  with 12 in 16
-State [FINAL] 15:
-  with 1 in 18
-  with 2 in 18
+State [FINAL] 14:
+  with 1 in 17
+  with 2 in 17
   with 3 in 18
-  with 4 in 19
-  with 10 in 18
-  with 11 in 18
-  with 12 in 18
+State [FINAL, FIXED_BASE] 15:
 State [FINAL, FIXED_BASE] 16:
+  with 1 in 19
 State [FINAL, FIXED_BASE] 17:
-  with 1 in 20
 State [FINAL, FIXED_BASE] 18:
+  with 1 in 20
 State [FINAL, FIXED_BASE] 19:
-  with 1 in 21
 State [FINAL, FIXED_BASE] 20:
-State [FINAL, FIXED_BASE] 21:
 
 
-22 states before minimization, 20 states in minimized DFA
+21 states before minimization, 19 states in minimized DFA
 Miniminal DFA is
 State 0:
   with 0 in 2
   with 1 in 3
+  with 2 in 2
+  with 3 in 2
   with 4 in 4
-  with 5 in 5
-  with 6 in 2
-  with 7 in 6
+  with 5 in 2
+  with 6 in 5
+  with 7 in 2
   with 8 in 2
-  with 9 in 2
 State 1:
   with 0 in 2
   with 1 in 3
+  with 2 in 2
+  with 3 in 2
   with 4 in 4
-  with 5 in 5
-  with 6 in 2
-  with 7 in 7
+  with 5 in 2
+  with 6 in 6
+  with 7 in 2
   with 8 in 2
-  with 9 in 2
 State [FINAL] 2:
 State [FINAL] 3:
 State [FINAL] 4:
 State [FINAL] 5:
+  with 5 in 7
 State [FINAL] 6:
-  with 6 in 8
-State [FINAL] 7:
-  with 6 in 9
+  with 5 in 8
+State 7:
+  with 7 in 9
 State 8:
-  with 8 in 10
+  with 7 in 10
 State 9:
-  with 8 in 11
+  with 7 in 11
 State 10:
-  with 8 in 12
+  with 7 in 12
 State 11:
   with 8 in 13
 State 12:
-  with 9 in 14
-State 13:
-  with 9 in 15
-State [FINAL] 14:
-  with 1 in 16
-  with 2 in 16
+  with 8 in 14
+State [FINAL] 13:
+  with 1 in 15
+  with 2 in 15
   with 3 in 16
-  with 4 in 17
-  with 10 in 16
-  with 11 in 16
-  with 12 in 16
-State [FINAL] 15:
-  with 1 in 18
-  with 2 in 18
+State [FINAL] 14:
+  with 1 in 17
+  with 2 in 17
   with 3 in 18
-  with 4 in 19
-  with 10 in 18
-  with 11 in 18
-  with 12 in 18
+State [FINAL, FIXED_BASE] 15:
 State [FINAL, FIXED_BASE] 16:
+  with 1 in 15
 State [FINAL, FIXED_BASE] 17:
-  with 1 in 16
 State [FINAL, FIXED_BASE] 18:
-State [FINAL, FIXED_BASE] 19:
-  with 1 in 18
+  with 1 in 17
 
 Writing code to "src/test/cases/bol/Bol.java"

--- a/testsuite/testcases/src/test/cases/bol/bol.flex
+++ b/testsuite/testcases/src/test/cases/bol/bol.flex
@@ -15,16 +15,13 @@
 
 %%
 
-// "hello" / [ \r\n]* "hello" { System.out.println("hello followed by hello"); }
+// "hello" / [ \n]* "hello" { System.out.println("hello followed by hello"); }
 ^"hello"$  { System.out.println("hello at BOL and EOL"); }
 ^"hello"   { System.out.println("hello at BOL"); }
 "hello"$   { System.out.println("hello at EOL"); }
 "hello"    { System.out.println("just hello");   }
 
-\r         { System.out.println("\\r"); }
 \n         { System.out.println("\\n"); }
 
 " "        { System.out.println( "\" \"" ); }
-.          { System.out.println( yytext() ); }
-
-
+[^]        { System.out.println( yytext() ); }

--- a/testsuite/testcases/src/test/cases/bol/bol2-0.input
+++ b/testsuite/testcases/src/test/cases/bol/bol2-0.input
@@ -1,7 +1,5 @@
 hello
-  hello
   hello  
-hello 
   hello
 hello 
  

--- a/testsuite/testcases/src/test/cases/bol/bol2-0.output
+++ b/testsuite/testcases/src/test/cases/bol/bol2-0.output
@@ -1,0 +1,70 @@
+match: --hello--
+action [13] { System.out.println("hello at BOL"); }
+hello at BOL
+match: --\u000A--
+action [16] { System.out.println("other"); }
+other
+match: -- --
+action [16] { System.out.println("other"); }
+other
+match: -- --
+action [16] { System.out.println("other"); }
+other
+match: --hello--
+action [14] { System.out.println("hello no BOL"); }
+hello no BOL
+match: -- --
+action [16] { System.out.println("other"); }
+other
+match: -- --
+action [16] { System.out.println("other"); }
+other
+match: --\u000A--
+action [16] { System.out.println("other"); }
+other
+match: -- --
+action [16] { System.out.println("other"); }
+other
+match: -- --
+action [16] { System.out.println("other"); }
+other
+match: --hello--
+action [14] { System.out.println("hello no BOL"); }
+hello no BOL
+match: --\u000A--
+action [16] { System.out.println("other"); }
+other
+match: --hello--
+action [13] { System.out.println("hello at BOL"); }
+hello at BOL
+match: -- --
+action [16] { System.out.println("other"); }
+other
+match: --\u000A--
+action [16] { System.out.println("other"); }
+other
+match: -- --
+action [16] { System.out.println("other"); }
+other
+match: --\u000A--
+action [16] { System.out.println("other"); }
+other
+match: --s--
+action [16] { System.out.println("other"); }
+other
+match: --d--
+action [16] { System.out.println("other"); }
+other
+match: --f--
+action [16] { System.out.println("other"); }
+other
+match: --a--
+action [16] { System.out.println("other"); }
+other
+match: --\u000A--
+action [16] { System.out.println("other"); }
+other
+match: --hello--
+action [13] { System.out.println("hello at BOL"); }
+hello at BOL
+-1

--- a/testsuite/testcases/src/test/cases/bol/bol2-flex.output
+++ b/testsuite/testcases/src/test/cases/bol/bol2-flex.output
@@ -1,0 +1,121 @@
+Reading "src/test/cases/bol/bol2.flex"
+CharClasses:
+class 0:
+{ [0-'d']['f'-'g']['i'-'k']['m'-'n']['p'-1114111] }
+class 1:
+{ ['e'] }
+class 2:
+{ ['h'] }
+class 3:
+{ ['l'] }
+class 4:
+{ ['o'] }
+
+Constructing NFA : NFA is
+State 0
+  with epsilon in {8, 14}
+State 1
+  with epsilon in {2, 8, 14}
+State 2
+  with 2 in {3}
+State 3
+  with 1 in {4}
+State 4
+  with 3 in {5}
+State 5
+  with 3 in {6}
+State 6
+  with 4 in {7}
+State[FINAL] 7
+State 8
+  with 2 in {9}
+State 9
+  with 1 in {10}
+State 10
+  with 3 in {11}
+State 11
+  with 3 in {12}
+State 12
+  with 4 in {13}
+State[FINAL] 13
+State 14
+  with 0 in {15}
+  with 1 in {15}
+  with 2 in {15}
+  with 3 in {15}
+  with 4 in {15}
+State[FINAL] 15
+
+
+16 states in NFA
+Converting NFA to DFA : 
+...........
+DFA is
+State 0:
+  with 0 in 2
+  with 1 in 2
+  with 2 in 3
+  with 3 in 2
+  with 4 in 2
+State 1:
+  with 0 in 2
+  with 1 in 2
+  with 2 in 4
+  with 3 in 2
+  with 4 in 2
+State [FINAL] 2:
+State [FINAL] 3:
+  with 1 in 5
+State [FINAL] 4:
+  with 1 in 6
+State 5:
+  with 3 in 7
+State 6:
+  with 3 in 8
+State 7:
+  with 3 in 9
+State 8:
+  with 3 in 10
+State 9:
+  with 4 in 11
+State 10:
+  with 4 in 12
+State [FINAL] 11:
+State [FINAL] 12:
+
+
+13 states before minimization, 13 states in minimized DFA
+Miniminal DFA is
+State 0:
+  with 0 in 2
+  with 1 in 2
+  with 2 in 3
+  with 3 in 2
+  with 4 in 2
+State 1:
+  with 0 in 2
+  with 1 in 2
+  with 2 in 4
+  with 3 in 2
+  with 4 in 2
+State [FINAL] 2:
+State [FINAL] 3:
+  with 1 in 5
+State [FINAL] 4:
+  with 1 in 6
+State 5:
+  with 3 in 7
+State 6:
+  with 3 in 8
+State 7:
+  with 3 in 9
+State 8:
+  with 3 in 10
+State 9:
+  with 4 in 11
+State 10:
+  with 4 in 12
+State [FINAL] 11:
+State [FINAL] 12:
+
+Writing code to "src/test/cases/bol/Bol2.java"

--- a/testsuite/testcases/src/test/cases/bol/bol2.flex
+++ b/testsuite/testcases/src/test/cases/bol/bol2.flex
@@ -1,0 +1,16 @@
+
+%%
+
+%public
+%class Bol2
+%integer
+%debug
+
+%unicode
+
+%%
+
+^"hello"   { System.out.println("hello at BOL"); }
+"hello"    { System.out.println("hello no BOL");   }
+
+[^]        { System.out.println("other"); }

--- a/testsuite/testcases/src/test/cases/bol/bol2.test
+++ b/testsuite/testcases/src/test/cases/bol/bol2.test
@@ -1,0 +1,7 @@
+name: bol2
+
+description:
+make sure that BOL operator works even if spec leads to no char class for
+newline characters.
+
+jflex: --nobak --dump


### PR DESCRIPTION
the atBOL matching is done in the runtime engine on raw characters and doesn't go through the `cmap`, so we don't need to create classes for that case.