### PR TITLE
Check %include files' modified times for rebuild too

### DIFF
--- a/jflex-maven-plugin/src/main/java/jflex/maven/plugin/jflex/ClassInfo.java
+++ b/jflex-maven-plugin/src/main/java/jflex/maven/plugin/jflex/ClassInfo.java
@@ -10,6 +10,9 @@ package jflex.maven.plugin.jflex;
 
 import com.google.common.base.Strings;
 import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 import javax.annotation.Nullable;
 
@@ -20,13 +23,24 @@ class ClassInfo {
   /** dot-separated package name. Empty string for the default package. */
   final String packageName;
 
+  final ArrayList<String> includedFiles;
+
   ClassInfo(String className, @Nullable String packageName) {
-    this.className = className;
-    this.packageName = Strings.nullToEmpty(packageName);
+    this(className, packageName, Collections.emptyList());
   }
 
+  ClassInfo(String className, @Nullable String packageName, List<String> includedFiles) {
+    this.className = className;
+    this.packageName = Strings.nullToEmpty(packageName);
+    this.includedFiles = new ArrayList<>(includedFiles);
+  }
+
+  /** Compares the className and packageName of instances, ignoring includedFiles. */
   @Override
   public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
     if (!(obj instanceof ClassInfo)) {
       return false;
     }
@@ -35,6 +49,7 @@ class ClassInfo {
         && Objects.equals(packageName, other.packageName);
   }
 
+  /** Computes a hash code from the className and packageName, ignoring includedFiles. */
   @Override
   public int hashCode() {
     return Objects.hash(className, packageName);

--- a/jflex-maven-plugin/src/test/java/jflex/maven/plugin/jflex/LexSimpleAnalyzerUtilsTest.java
+++ b/jflex-maven-plugin/src/test/java/jflex/maven/plugin/jflex/LexSimpleAnalyzerUtilsTest.java
@@ -4,6 +4,7 @@ import static com.google.common.truth.Truth.assertThat;
 
 import java.io.IOException;
 import java.io.StringReader;
+import java.util.Arrays;
 import org.junit.Test;
 
 /** Test for {@link LexSimpleAnalyzerUtils}. */
@@ -79,6 +80,20 @@ public class LexSimpleAnalyzerUtilsTest {
             + "}\n"
             + "\n";
     assertThat(guessPackageAndClass(lex)).isEqualTo(new ClassInfo("Yylex", null));
+  }
+
+  @Test
+  public void guessPackageAndClass_with_includedFiles() throws Exception {
+    String lex =
+        "\n"
+            + "package org.example;\n"
+            + "\n"
+            + "import java.io.File;\n"
+            + "\n"
+            + "\t%include  base.lexh\t \n";
+    ClassInfo classInfo = guessPackageAndClass(lex);
+    assertThat(classInfo).isEqualTo(new ClassInfo("Yylex", "org.example"));
+    assertThat(classInfo.includedFiles).containsExactlyElementsIn(Arrays.asList("base.lexh"));
   }
 
   private ClassInfo guessPackageAndClass(String lex) throws IOException {


### PR DESCRIPTION
Hello,

Please consider for integration this patch for the jflex-maven-plugin to check also last-modified times for `%include` files in a JFlex file when possibly short-circuiting a rebuild. (It had been suggested in #217 that the jflex-maven-plugin supported this already, but I did not find that to be the case.)

Only `%include` files directly referenced by a `lexFile` would be checked by this patch and not any nested `%include` statements.

Thank you.
