### PR TITLE
memory performance: two-level cmap lookup

### DIFF
--- a/javatests/jflex/testcase/include/skeleton.nested
+++ b/javatests/jflex/testcase/include/skeleton.nested
@@ -36,7 +36,7 @@
 
   /** the textposition at the last accepting state */
   private int zzMarkedPos;
-  
+
   /** the current text position in the buffer */
   private int zzCurrentPos;
 
@@ -54,12 +54,12 @@
   private int yychar;
 
   /**
-   * the number of characters from the last newline up to the start of the 
+   * the number of characters from the last newline up to the start of the
    * matched text
    */
   private int yycolumn;
 
-  /** 
+  /**
    * zzAtBOL == true <=> the scanner is currently at the beginning of a line
    */
   private boolean zzAtBOL = true;
@@ -69,8 +69,8 @@
 
   /** denotes if the user-EOF-code has already been executed */
   private boolean zzEOFDone;
-  
-  /** 
+
+  /**
    * The number of occupied positions in zzBuffer beyond zzEndRead.
    * When a lead/high surrogate has been read from the input stream
    * into the final zzBuffer position, this will have a value of 1;
@@ -103,7 +103,7 @@
 
     /** sets all values stored in this class */
     ZzFlexStreamInfo(java.io.Reader zzReader, int zzEndRead, int zzStartRead,
-                  int zzCurrentPos, int zzMarkedPos, char [] zzBuffer, 
+                  int zzCurrentPos, int zzMarkedPos, char [] zzBuffer,
                   boolean zzAtBOL, boolean zzAtEOF, boolean zzEOFDone,
                   int zzFinalHighSurrogate, int yyline, int yychar, int yycolumn) {
       this.zzReader      = zzReader;
@@ -131,7 +131,7 @@
    * Refills the input buffer.
    *
    * @return      <code>false</code>, iff there was new input.
-   * 
+   *
    * @exception   java.io.IOException  if any I/O-Error occurs
    */
   private boolean zzRefill() throws java.io.IOException {
@@ -183,7 +183,7 @@
     return true;
   }
 
-    
+
   /**
    * Closes the input stream.
    */
@@ -223,11 +223,11 @@
     zzFinalHighSurrogate = 0;
     yyline = yychar = yycolumn = 0;
   }
-    
+
 
   /**
    * Closes the current input stream and continues to
-   * read from the one on top of the stream stack. 
+   * read from the one on top of the stream stack.
    *
    * @throws java.util.EmptyStackException
    *         if there is no further stream to read from.
@@ -257,7 +257,7 @@
 
 
   /**
-   * Returns true iff there are still streams left 
+   * Returns true iff there are still streams left
    * to read from on the stream stack.
    */
   public final boolean yymoreStreams() {
@@ -269,13 +269,13 @@
    * Resets the scanner to read from a new input stream.
    * Does not close the old reader.
    *
-   * All internal variables are reset, the old input stream 
+   * All internal variables are reset, the old input stream
    * <b>cannot</b> be reused (internal buffer is discarded and lost).
    * Lexical state is set to <tt>ZZ_INITIAL</tt>.
    *
    * Internal scan buffer is resized down to its initial length, if it has grown.
    *
-   * @param reader   the new input stream 
+   * @param reader   the new input stream
    *
    * @see #yypushStream(java.io.Reader)
    * @see #yypopStream()
@@ -329,12 +329,12 @@
 
 
   /**
-   * Returns the character at position <tt>pos</tt> from the 
-   * matched text. 
-   * 
+   * Returns the character at position <tt>pos</tt> from the
+   * matched text.
+   *
    * It is equivalent to yytext().charAt(pos), but faster
    *
-   * @param pos the position of the character to fetch. 
+   * @param pos the position of the character to fetch.
    *            A value from 0 to yylength()-1.
    *
    * @return the character at position pos
@@ -355,8 +355,8 @@
   /**
    * Reports an error that occured while scanning.
    *
-   * In a wellformed scanner (no or only correct usage of 
-   * yypushback(int) and a match-all fallback rule) this method 
+   * In a wellformed scanner (no or only correct usage of
+   * yypushback(int) and a match-all fallback rule) this method
    * will only be called with things that "Can't Possibly Happen".
    * If this method is called, something is seriously wrong
    * (e.g. a JFlex bug producing a faulty scanner etc.).
@@ -376,7 +376,7 @@
     }
 
 --- throws clause
-  } 
+  }
 
 
   /**
@@ -415,18 +415,17 @@
       int zzMarkedPosL = zzMarkedPos;
       int zzEndReadL = zzEndRead;
       char [] zzBufferL = zzBuffer;
-      char [] zzCMapL = ZZ_CMAP;
 
 --- start admin (line, char, col count)
       zzAction = -1;
 
       zzCurrentPosL = zzCurrentPos = zzStartRead = zzMarkedPosL;
-  
+
 --- start admin (lexstate etc)
 
       zzForAction: {
         while (true) {
-    
+
 --- next input, line, col, char count, next transition, isFinal action
             zzAction = zzState;
             zzMarkedPosL = zzCurrentPosL;

--- a/javatests/jflex/testcase/include2/skeleton.nested
+++ b/javatests/jflex/testcase/include2/skeleton.nested
@@ -36,7 +36,7 @@
 
   /** the textposition at the last accepting state */
   private int zzMarkedPos;
-  
+
   /** the current text position in the buffer */
   private int zzCurrentPos;
 
@@ -54,12 +54,12 @@
   private int yychar;
 
   /**
-   * the number of characters from the last newline up to the start of the 
+   * the number of characters from the last newline up to the start of the
    * matched text
    */
   private int yycolumn;
 
-  /** 
+  /**
    * zzAtBOL == true <=> the scanner is currently at the beginning of a line
    */
   private boolean zzAtBOL = true;
@@ -69,8 +69,8 @@
 
   /** denotes if the user-EOF-code has already been executed */
   private boolean zzEOFDone;
-  
-  /** 
+
+  /**
    * The number of occupied positions in zzBuffer beyond zzEndRead.
    * When a lead/high surrogate has been read from the input stream
    * into the final zzBuffer position, this will have a value of 1;
@@ -103,7 +103,7 @@
 
     /** sets all values stored in this class */
     ZzFlexStreamInfo(java.io.Reader zzReader, int zzEndRead, int zzStartRead,
-                  int zzCurrentPos, int zzMarkedPos, char [] zzBuffer, 
+                  int zzCurrentPos, int zzMarkedPos, char [] zzBuffer,
                   boolean zzAtBOL, boolean zzAtEOF, boolean zzEOFDone,
                   int zzFinalHighSurrogate, int yyline, int yychar, int yycolumn) {
       this.zzReader      = zzReader;
@@ -131,7 +131,7 @@
    * Refills the input buffer.
    *
    * @return      <code>false</code>, iff there was new input.
-   * 
+   *
    * @exception   java.io.IOException  if any I/O-Error occurs
    */
   private boolean zzRefill() throws java.io.IOException {
@@ -183,7 +183,7 @@
     return true;
   }
 
-    
+
   /**
    * Closes the input stream.
    */
@@ -223,11 +223,11 @@
     zzFinalHighSurrogate = 0;
     yyline = yychar = yycolumn = 0;
   }
-    
+
 
   /**
    * Closes the current input stream and continues to
-   * read from the one on top of the stream stack. 
+   * read from the one on top of the stream stack.
    *
    * @throws java.util.EmptyStackException
    *         if there is no further stream to read from.
@@ -257,7 +257,7 @@
 
 
   /**
-   * Returns true iff there are still streams left 
+   * Returns true iff there are still streams left
    * to read from on the stream stack.
    */
   public final boolean yymoreStreams() {
@@ -269,13 +269,13 @@
    * Resets the scanner to read from a new input stream.
    * Does not close the old reader.
    *
-   * All internal variables are reset, the old input stream 
+   * All internal variables are reset, the old input stream
    * <b>cannot</b> be reused (internal buffer is discarded and lost).
    * Lexical state is set to <tt>ZZ_INITIAL</tt>.
    *
    * Internal scan buffer is resized down to its initial length, if it has grown.
    *
-   * @param reader   the new input stream 
+   * @param reader   the new input stream
    *
    * @see #yypushStream(java.io.Reader)
    * @see #yypopStream()
@@ -328,12 +328,12 @@
 
 
   /**
-   * Returns the character at position <tt>pos</tt> from the 
-   * matched text. 
-   * 
+   * Returns the character at position <tt>pos</tt> from the
+   * matched text.
+   *
    * It is equivalent to yytext().charAt(pos), but faster
    *
-   * @param pos the position of the character to fetch. 
+   * @param pos the position of the character to fetch.
    *            A value from 0 to yylength()-1.
    *
    * @return the character at position pos
@@ -354,8 +354,8 @@
   /**
    * Reports an error that occured while scanning.
    *
-   * In a wellformed scanner (no or only correct usage of 
-   * yypushback(int) and a match-all fallback rule) this method 
+   * In a wellformed scanner (no or only correct usage of
+   * yypushback(int) and a match-all fallback rule) this method
    * will only be called with things that "Can't Possibly Happen".
    * If this method is called, something is seriously wrong
    * (e.g. a JFlex bug producing a faulty scanner etc.).
@@ -375,7 +375,7 @@
     }
 
 --- throws clause
-  } 
+  }
 
 
   /**
@@ -414,18 +414,17 @@
       int zzMarkedPosL = zzMarkedPos;
       int zzEndReadL = zzEndRead;
       char [] zzBufferL = zzBuffer;
-      char [] zzCMapL = ZZ_CMAP;
 
 --- start admin (line, char, col count)
       zzAction = -1;
 
       zzCurrentPosL = zzCurrentPos = zzStartRead = zzMarkedPosL;
-  
+
 --- start admin (lexstate etc)
 
       zzForAction: {
         while (true) {
-    
+
 --- next input, line, col, char count, next transition, isFinal action
             zzAction = zzState;
             zzMarkedPosL = zzCurrentPosL;

--- a/jflex/src/main/java/jflex/base/Pair.java
+++ b/jflex/src/main/java/jflex/base/Pair.java
@@ -1,0 +1,45 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * JFlex 1.8.0-SNAPSHOT                                                    *
+ * Copyright (C) 1998-2018  Gerwin Klein <lsf@jflex.de>                    *
+ * All rights reserved.                                                    *
+ *                                                                         *
+ * License: BSD                                                            *
+ *                                                                         *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+package jflex.base;
+
+import java.util.Objects;
+
+/**
+ * Generic immutable pair.
+ *
+ * @author Gerwin Klein
+ * @version JFlex 1.8.0-SNAPSHOT
+ */
+public class Pair<A, B> {
+  public final A fst;
+  public final B snd;
+
+  public Pair(A fst, B snd) {
+    this.fst = fst;
+    this.snd = snd;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(fst, snd);
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    return other instanceof Pair<?, ?>
+        && Objects.equals(fst, ((Pair<?, ?>) other).fst)
+        && Objects.equals(snd, ((Pair<?, ?>) other).snd);
+  }
+
+  @Override
+  public String toString() {
+    return "(" + fst + ", " + snd + ")";
+  }
+}

--- a/jflex/src/main/java/jflex/core/unicode/BUILD.bazel
+++ b/jflex/src/main/java/jflex/core/unicode/BUILD.bazel
@@ -3,6 +3,7 @@ java_library(
     srcs = glob(["data/*.java"]) + [
         "CharClasses.java",
         "CharClassInterval.java",
+        "CMapBlock.java",
         "IntCharSet.java",
         "IntCharSetComparator.java",
         "ILexScan.java",

--- a/jflex/src/main/java/jflex/core/unicode/CMapBlock.java
+++ b/jflex/src/main/java/jflex/core/unicode/CMapBlock.java
@@ -1,0 +1,49 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * JFlex 1.8.0-SNAPSHOT                                                    *
+ * Copyright (C) 1998-2018  Gerwin Klein <lsf@jflex.de>                    *
+ * All rights reserved.                                                    *
+ *                                                                         *
+ * License: BSD                                                            *
+ *                                                                         *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+package jflex.core.unicode;
+
+import java.util.Arrays;
+
+/** Immutable second-level blocks for constructing the two-level character map table. */
+public class CMapBlock {
+  /** How many bits the second-level char map tables translate */
+  public static final int BLOCK_BITS = 8;
+  /** Size of the second-level char map arrays */
+  public static final int BLOCK_SIZE = 1 << BLOCK_BITS;
+
+  /** array of BLOCK_SIZE; reference immutable; contents intended to be as well */
+  public final int[] block;
+  /** pre-computed hash, since we will compare often */
+  private final int hash;
+
+  /**
+   * Constructs new CMapBlock and pre-computes its hash
+   *
+   * @param block an int array of size @{link BLOCK_SIZE}.
+   */
+  public CMapBlock(int[] block) {
+    assert block.length == BLOCK_SIZE : block;
+    this.block = block;
+    this.hash = Arrays.hashCode(block);
+  }
+
+  @Override
+  public int hashCode() {
+    return hash;
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    return this == other
+        || (other instanceof CMapBlock
+            && hash == ((CMapBlock) other).hash
+            && Arrays.equals(block, ((CMapBlock) other).block));
+  }
+}

--- a/jflex/src/main/java/jflex/core/unicode/CharClassInterval.java
+++ b/jflex/src/main/java/jflex/core/unicode/CharClassInterval.java
@@ -46,6 +46,11 @@ public class CharClassInterval {
     this.charClass = charClass;
   }
 
+  /** Determines wether the specified code point is in this interval. */
+  public boolean contains(int codePoint) {
+    return start <= codePoint && codePoint <= end;
+  }
+
   @Override
   public String toString() {
     return "[" + start + "-" + end + "=" + charClass + "]";

--- a/jflex/src/main/java/jflex/core/unicode/CharClasses.java
+++ b/jflex/src/main/java/jflex/core/unicode/CharClasses.java
@@ -14,6 +14,7 @@ import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
+import jflex.base.Pair;
 import jflex.chars.Interval;
 import jflex.logging.Out;
 
@@ -28,7 +29,8 @@ public class CharClasses {
   /** debug flag (for char classes only) */
   private static final boolean DEBUG = false;
 
-  private Comparator<IntCharSet> INT_CHAR_SET_COMPARATOR = new IntCharSetComparator();
+  /** for sorting disjoint IntCharSets */
+  private static final Comparator<IntCharSet> INT_CHAR_SET_COMPARATOR = new IntCharSetComparator();
 
   /** the largest character that can be used in char classes */
   public static final int maxChar = 0x10FFFF;
@@ -39,7 +41,7 @@ public class CharClasses {
   /** the largest character actually used in a specification */
   private int maxCharUsed;
 
-  /** the @{link UnicodeProperties} the scanner used */
+  /** the @{link UnicodeProperties} the spec scanner used */
   private UnicodeProperties unicodeProps;
 
   /**
@@ -320,6 +322,35 @@ public class CharClasses {
   }
 
   /**
+   * Brings the partitions into a canonical order such that objects that implement the same
+   * partitions but in different order become equal.
+   *
+   * <p>For example, [ {0}, {1} ] and [ {1}, {0} ] implement the same partition of the set {0,1} but
+   * have different content. Different order will lead to different input assignments in the NFA and
+   * DFA phases and will make otherwise equal automata look distinct.
+   *
+   * <p>This is not needed for correctness, but it makes the comparison of output DFAs (e.g. in the
+   * test suite) for equivalence more robust.
+   */
+  public void normalise() {
+    classes.sort(INT_CHAR_SET_COMPARATOR);
+  }
+
+  /**
+   * Construct a (deep) copy of the the provided CharClasses object.
+   *
+   * @param c the CharClasses to copy
+   * @return a deep copy of c
+   */
+  public static CharClasses copyOf(CharClasses c) {
+    CharClasses result = new CharClasses();
+    result.maxCharUsed = c.maxCharUsed;
+    result.unicodeProps = c.unicodeProps;
+    result.classes = c.allClasses();
+    return result;
+  }
+
+  /**
    * Returns an array of all CharClassIntervals in this char class collection.
    *
    * <p>The array is ordered by char code, i.e. {@code result[i+1].start = result[i].end+1} Each
@@ -352,31 +383,59 @@ public class CharClasses {
   }
 
   /**
-   * Brings the partitions into a canonical order such that objects that implement the same
-   * partitions but in different order become equal.
+   * Computes a two-level table structure representing this CharClass object, where second-level
+   * blocks are shared if equal. The hope is that this sharing happens (very) often with a large
+   * number of blocks being mapped to the same character class.
    *
-   * <p>For example, [ {0}, {1} ] and [ {1}, {0} ] implement the same partition of the set {0,1} but
-   * have different content. Different order will lead to different input assignments in the NFA and
-   * DFA phases and will make otherwise equal automata look distinct.
-   *
-   * <p>This is not needed for correctness, but it makes the comparison of output DFAs (e.g. in the
-   * test suite) for equivalence more robust.
+   * @return a pair of a top-level table, and a list of second-level blocks for this char class
+   *     object.
    */
-  public void normalise() {
-    classes.sort(INT_CHAR_SET_COMPARATOR);
+  Pair<int[], List<CMapBlock>> computeTables() {
+    int topLevelSize = (maxCharUsed + 1) >> CMapBlock.BLOCK_BITS;
+    int[] topLevel = new int[topLevelSize];
+    List<CMapBlock> blocks = new ArrayList<>();
+
+    for (int topIndex = 0; topIndex < topLevelSize; topIndex++) {
+      int[] block = new int[CMapBlock.BLOCK_SIZE];
+      for (int i = 0; i < CMapBlock.BLOCK_SIZE; i++) {
+        int codePoint = (topIndex << CMapBlock.BLOCK_BITS) | i;
+        // if maxCharUsed doesn't align to CMapBlock.BLOCK_BITS, we leave the rest of the highest
+        // block 0.
+        if (maxCharUsed < codePoint) break;
+        block[i] = getClassCode(codePoint);
+      }
+      // find earliest equal block (if any)
+      CMapBlock b = new CMapBlock(block);
+      int idx = blocks.indexOf(b);
+      if (idx < 0) {
+        idx = blocks.size();
+        blocks.add(b);
+      }
+      topLevel[topIndex] = idx;
+    }
+    return new Pair<int[], List<CMapBlock>>(topLevel, blocks);
+  }
+
+  /** Turn a list of second-level blocks into a flat array. */
+  private static int[] flattenBlocks(List<CMapBlock> blocks) {
+    int[] result = new int[blocks.size() * CMapBlock.BLOCK_SIZE];
+    for (int i = 0; i < blocks.size(); i++) {
+      int[] block = blocks.get(i).block;
+      System.arraycopy(block, 0, result, i << CMapBlock.BLOCK_BITS, CMapBlock.BLOCK_SIZE);
+    }
+    return result;
   }
 
   /**
-   * Construct a (deep) copy of the the provided CharClasses object.
+   * Returns a two-level table structure for this char-class object. The char class of input {@code
+   * x} is {@code snd[(fst[x >> BLOCK_BITS] << BLOCK_BITS) | (x && BLOCK_MASK))]} where {@code
+   * BLOCK_MASK = BLOCK_SIZE - 1}
    *
-   * @param c the CharClasses to copy
-   * @return a deep copy of c
+   * @see CMapBlock#BLOCK_BITS
+   * @see CMapBlock#BLOCK_SIZE
    */
-  public static CharClasses copyOf(CharClasses c) {
-    CharClasses result = new CharClasses();
-    result.maxCharUsed = c.maxCharUsed;
-    result.unicodeProps = c.unicodeProps;
-    result.classes = c.allClasses();
-    return result;
+  public Pair<int[], int[]> getTables() {
+    Pair<int[], List<CMapBlock>> p = computeTables();
+    return new Pair<int[], int[]>(p.fst, flattenBlocks(p.snd));
   }
 }

--- a/jflex/src/main/java/jflex/core/unicode/CharClasses.java
+++ b/jflex/src/main/java/jflex/core/unicode/CharClasses.java
@@ -391,18 +391,25 @@ public class CharClasses {
    *     object.
    */
   Pair<int[], List<CMapBlock>> computeTables() {
+    CharClassInterval[] intervals = getIntervals();
+    int intervalIndex = 0;
+    int curClass = intervals[intervalIndex].charClass;
+    int codePoint = 0;
+
     int topLevelSize = (maxCharUsed + 1) >> CMapBlock.BLOCK_BITS;
     int[] topLevel = new int[topLevelSize];
     List<CMapBlock> blocks = new ArrayList<>();
 
     for (int topIndex = 0; topIndex < topLevelSize; topIndex++) {
       int[] block = new int[CMapBlock.BLOCK_SIZE];
-      for (int i = 0; i < CMapBlock.BLOCK_SIZE; i++) {
-        int codePoint = (topIndex << CMapBlock.BLOCK_BITS) | i;
-        // if maxCharUsed doesn't align to CMapBlock.BLOCK_BITS, we leave the rest of the highest
-        // block 0.
+      for (int i = 0; i < CMapBlock.BLOCK_SIZE; i++, codePoint++) {
+        // if maxCharUsed doesn't align to CMapBlock.BLOCK_BITS, we leave the
+        // rest of the highest block equal to 0.
         if (maxCharUsed < codePoint) break;
-        block[i] = getClassCode(codePoint);
+        if (!intervals[intervalIndex].contains(codePoint)) {
+          curClass = intervals[++intervalIndex].charClass;
+        }
+        block[i] = curClass;
       }
       // find earliest equal block (if any)
       CMapBlock b = new CMapBlock(block);

--- a/jflex/src/main/java/jflex/core/unicode/IntCharSet.java
+++ b/jflex/src/main/java/jflex/core/unicode/IntCharSet.java
@@ -34,7 +34,7 @@ public final class IntCharSet implements Iterable<Integer> {
   private static final boolean DEBUG = false;
 
   /* invariant: all intervals are disjoint, ordered */
-  private List<Interval> intervals = new ArrayList<>();
+  private final List<Interval> intervals = new ArrayList<>();
 
   /** Creates a charset that contains only one interval. */
   public static IntCharSet of(Interval interval) {
@@ -159,6 +159,7 @@ public final class IntCharSet implements Iterable<Integer> {
    *
    * @param interval a {@link jflex.chars.Interval} object.
    */
+  @SuppressWarnings("IncrementInForLoopAndHeader")
   public void add(Interval interval) {
     if (DEBUG) assert interval.invariants();
 

--- a/jflex/src/main/java/jflex/generator/CountEmitter.java
+++ b/jflex/src/main/java/jflex/generator/CountEmitter.java
@@ -104,7 +104,39 @@ public class CountEmitter extends PackEmitter {
   public void emit(int count, int value) {
     numEntries += count;
     breaks();
+
+    // unlikely, but count could be >= 0x10000
+    while (count > 0xFFFF) {
+      emitUC(0xFFFF);
+      emitUC(value + translate);
+      count -= 0xFFFF;
+    }
+
     emitUC(count);
     emitUC(value + translate);
+  }
+
+  /**
+   * Emits a plain int array as a count/value string. Expects the preamble code (declaration,
+   * javadoc) to already be emitted. Values in the array must be no larger than 0xFFFF (encoded as
+   * char), array must have at least one element.
+   *
+   * @returns the number of count/value pairs in the packed array
+   */
+  public void emitCountValueString(int[] a) {
+    assert a.length > 0;
+
+    int count = 0;
+    int value = a[0];
+    for (int i = 0; i < a.length; i++) {
+      if (value == a[i]) {
+        count++;
+      } else {
+        emit(count, value);
+        count = 1;
+        value = a[i];
+      }
+    }
+    emit(count, value);
   }
 }

--- a/jflex/src/main/jflex/skeleton.nested
+++ b/jflex/src/main/jflex/skeleton.nested
@@ -36,7 +36,7 @@
 
   /** the textposition at the last accepting state */
   private int zzMarkedPos;
-  
+
   /** the current text position in the buffer */
   private int zzCurrentPos;
 
@@ -54,12 +54,12 @@
   private long yychar;
 
   /**
-   * the number of characters from the last newline up to the start of the 
+   * the number of characters from the last newline up to the start of the
    * matched text
    */
   private int yycolumn;
 
-  /** 
+  /**
    * zzAtBOL == true iff the scanner is currently at the beginning of a line
    */
   private boolean zzAtBOL = true;
@@ -72,8 +72,8 @@
 
   /** denotes if the user-EOF-code has already been executed */
   private boolean zzEOFDone;
-  
-  /** 
+
+  /**
    * The number of occupied positions in zzBuffer beyond zzEndRead.
    * When a lead/high surrogate has been read from the input stream
    * into the final zzBuffer position, this will have a value of 1;
@@ -106,7 +106,7 @@
 
     /** sets all values stored in this class */
     ZzFlexStreamInfo(java.io.Reader zzReader, int zzEndRead, int zzStartRead,
-                  int zzCurrentPos, int zzMarkedPos, char [] zzBuffer, 
+                  int zzCurrentPos, int zzMarkedPos, char [] zzBuffer,
                   boolean zzAtBOL, boolean zzAtEOF, boolean zzEOFDone,
                   int zzFinalHighSurrogate, int yyline, long yychar,
                   int yycolumn) {
@@ -135,7 +135,7 @@
    * Refills the input buffer.
    *
    * @return      <code>false</code>, iff there was new input.
-   * 
+   *
    * @exception   java.io.IOException  if any I/O-Error occurs
    */
   private boolean zzRefill() throws java.io.IOException {
@@ -230,11 +230,11 @@
     zzReader = reader;
     yyResetPosition();
   }
-    
+
 
   /**
    * Closes the current input stream and continues to
-   * read from the one on top of the stream stack. 
+   * read from the one on top of the stream stack.
    *
    * @throws java.util.EmptyStackException
    *         if there is no further stream to read from.
@@ -264,7 +264,7 @@
 
 
   /**
-   * Returns true iff there are still streams left 
+   * Returns true iff there are still streams left
    * to read from on the stream stack.
    */
   public final boolean yymoreStreams() {
@@ -276,13 +276,13 @@
    * Resets the scanner to read from a new input stream.
    * Does not close the old reader.
    *
-   * All internal variables are reset, the old input stream 
+   * All internal variables are reset, the old input stream
    * <b>cannot</b> be reused (internal buffer is discarded and lost).
    * Lexical state is set to <tt>ZZ_INITIAL</tt>.
    *
    * Internal scan buffer is resized down to its initial length, if it has grown.
    *
-   * @param reader   the new input stream 
+   * @param reader   the new input stream
    *
    * @see #yypushStream(java.io.Reader)
    * @see #yypopStream()
@@ -345,12 +345,12 @@
 
 
   /**
-   * Returns the character at position <tt>pos</tt> from the 
-   * matched text. 
-   * 
+   * Returns the character at position <tt>pos</tt> from the
+   * matched text.
+   *
    * It is equivalent to yytext().charAt(pos), but faster
    *
-   * @param pos the position of the character to fetch. 
+   * @param pos the position of the character to fetch.
    *            A value from 0 to yylength()-1.
    *
    * @return the character at position pos
@@ -371,8 +371,8 @@
   /**
    * Reports an error that occured while scanning.
    *
-   * In a wellformed scanner (no or only correct usage of 
-   * yypushback(int) and a match-all fallback rule) this method 
+   * In a wellformed scanner (no or only correct usage of
+   * yypushback(int) and a match-all fallback rule) this method
    * will only be called with things that "Can't Possibly Happen".
    * If this method is called, something is seriously wrong
    * (e.g. a JFlex bug producing a faulty scanner etc.).
@@ -392,7 +392,7 @@
     }
 
 --- throws clause
-  } 
+  }
 
 
   /**
@@ -437,12 +437,12 @@
       zzAction = -1;
 
       zzCurrentPosL = zzCurrentPos = zzStartRead = zzMarkedPosL;
-  
+
 --- start admin (lexstate etc)
 
       zzForAction: {
         while (true) {
-    
+
 --- next input, line, col, char count, next transition, isFinal action
             zzAction = zzState;
             zzMarkedPosL = zzCurrentPosL;

--- a/jflex/src/main/jflex/skeleton.nested-1.8.0
+++ b/jflex/src/main/jflex/skeleton.nested-1.8.0
@@ -51,7 +51,7 @@
   private int yyline;
 
   /** the number of characters up to the start of the matched text */
-  private int yychar;
+  private long yychar;
 
   /**
    * the number of characters from the last newline up to the start of the
@@ -60,11 +60,14 @@
   private int yycolumn;
 
   /**
-   * zzAtBOL == true <=> the scanner is currently at the beginning of a line
+   * zzAtBOL == true iff the scanner is currently at the beginning of a line
    */
   private boolean zzAtBOL = true;
 
-  /** zzAtEOF == true <=> the scanner is at the EOF */
+  /**
+   * Whether the scanner is at the end of file.
+   * @see #yyatEOF
+   */
   private boolean zzAtEOF;
 
   /** denotes if the user-EOF-code has already been executed */
@@ -93,7 +96,7 @@
     int zzCurrentPos;
     int zzMarkedPos;
     int yyline;
-    int yychar;
+    long yychar;
     int yycolumn;
     char [] zzBuffer;
     boolean zzAtBOL;
@@ -105,7 +108,8 @@
     ZzFlexStreamInfo(java.io.Reader zzReader, int zzEndRead, int zzStartRead,
                   int zzCurrentPos, int zzMarkedPos, char [] zzBuffer,
                   boolean zzAtBOL, boolean zzAtEOF, boolean zzEOFDone,
-                  int zzFinalHighSurrogate, int yyline, int yychar, int yycolumn) {
+                  int zzFinalHighSurrogate, int yyline, long yychar,
+                  int yycolumn) {
       this.zzReader      = zzReader;
       this.zzEndRead     = zzEndRead;
       this.zzStartRead   = zzStartRead;
@@ -165,31 +169,39 @@
     int requested = zzBuffer.length - zzEndRead;
     int numRead = zzReader.read(zzBuffer, zzEndRead, requested);
 
-    // unlikely but not impossible: read 0 characters, but not at end of stream
+    /* not supposed to occur according to specification of java.io.Reader */
     if (numRead == 0) {
-      numRead = zzReader.read(zzBuffer, zzEndRead, requested);
+      throw new java.io.IOException("Reader returned 0 characters. See JFlex examples for workaround.");
     }
     if (numRead > 0) {
       zzEndRead += numRead;
-      if (numRead == requested) { /* possibly more input available */
-        if (Character.isHighSurrogate(zzBuffer[zzEndRead - 1])) {
+      if (Character.isHighSurrogate(zzBuffer[zzEndRead - 1])) {
+        if (numRead == requested) { // We requested too few chars to encode a full Unicode character
           --zzEndRead;
           zzFinalHighSurrogate = 1;
+        } else {                    // There is room in the buffer for at least one more char
+          int c = zzReader.read();  // Expecting to read a paired low surrogate char
+          if (c == -1) {
+            return true;
+          } else {
+            zzBuffer[zzEndRead++] = (char)c;
+          }
         }
       }
+      /* potentially more input available */
       return false;
     }
 
+    /* numRead < 0 ==> end of stream */
     return true;
   }
-
 
   /**
    * Closes the input stream.
    */
   public final void yyclose() throws java.io.IOException {
-    zzAtEOF = true;            /* indicate end of file */
-    zzEndRead = zzStartRead;  /* invalidate buffer    */
+    zzAtEOF = true;           // indicate end of file
+    zzEndRead = zzStartRead;  // invalidate buffer
 
     if (zzReader != null)
       zzReader.close();
@@ -214,14 +226,9 @@
                         zzMarkedPos, zzBuffer, zzAtBOL, zzAtEOF, zzEOFDone,
                         zzFinalHighSurrogate, yyline, yychar, yycolumn)
     );
-    zzAtBOL  = true;
-    zzAtEOF  = false;
     zzBuffer = new char[ZZ_BUFFERSIZE];
     zzReader = reader;
-    zzEndRead = zzStartRead = 0;
-    zzCurrentPos = zzMarkedPos = 0;
-    zzFinalHighSurrogate = 0;
-    yyline = yychar = yycolumn = 0;
+    yyResetPosition();
   }
 
 
@@ -282,16 +289,32 @@
    */
   public final void yyreset(java.io.Reader reader) {
     zzReader = reader;
-    zzAtBOL  = true;
-    zzAtEOF  = false;
     zzEOFDone = false;
-    zzEndRead = zzStartRead = 0;
-    zzCurrentPos = zzMarkedPos = 0;
-    zzFinalHighSurrogate = 0;
-    yyline = yychar = yycolumn = 0;
+    yyResetPosition();
     zzLexicalState = YYINITIAL;
-    if (zzBuffer.length > ZZ_BUFFERSIZE)
+    if (zzBuffer.length > ZZ_BUFFERSIZE) {
       zzBuffer = new char[ZZ_BUFFERSIZE];
+    }
+  }
+
+  private final void yyResetPosition() {
+      zzAtBOL  = true;
+      zzAtEOF  = false;
+      zzCurrentPos = 0;
+      zzMarkedPos = 0;
+      zzStartRead = 0;
+      zzEndRead = 0;
+      zzFinalHighSurrogate = 0;
+      yyline = 0;
+      yycolumn = 0;
+      yychar = 0L;
+  }
+
+  /**
+   * Returns whether the scanner has reached the end of the reader it reads from.
+   */
+  public final boolean yyatEOF() {
+    return zzAtEOF;
   }
 
 

--- a/jflex/src/main/resources/jflex/skeleton.default
+++ b/jflex/src/main/resources/jflex/skeleton.default
@@ -151,7 +151,7 @@
     return true;
   }
 
-    
+
   /**
    * Closes the input stream.
    */
@@ -238,7 +238,7 @@
 
   /**
    * Returns the character at the given position from the matched text.
-   * 
+   *
    * <p>It is equivalent to {@code yytext().charAt(pos)}, but faster.
    *
    * @param position the position of the character to fetch. A value from 0 to {@code yylength()-1}.
@@ -281,7 +281,7 @@
     }
 
 --- throws clause
-  } 
+  }
 
 
   /**
@@ -319,7 +319,6 @@
     int zzMarkedPosL;
     int zzEndReadL = zzEndRead;
     char[] zzBufferL = zzBuffer;
-    char[] zzCMapL = ZZ_CMAP;
 
 --- local declarations
 
@@ -330,12 +329,12 @@
       zzAction = -1;
 
       zzCurrentPosL = zzCurrentPos = zzStartRead = zzMarkedPosL;
-  
+
 --- start admin (lexstate etc)
 
       zzForAction: {
         while (true) {
-    
+
 --- next input, line, col, char count, next transition, isFinal action
             zzAction = zzState;
             zzMarkedPosL = zzCurrentPosL;

--- a/jflex/src/test/java/jflex/core/unicode/BUILD.bazel
+++ b/jflex/src/test/java/jflex/core/unicode/BUILD.bazel
@@ -7,6 +7,7 @@ java_test(
     ],
     deps = [
         "IntCharSetQuickcheck",
+        "//jflex/src/main/java/jflex/base",
         "//jflex/src/main/java/jflex/chars",
         "//jflex/src/main/java/jflex/core",
         "//jflex/src/main/java/jflex/core/unicode",

--- a/jflex/src/test/java/jflex/core/unicode/CharClassesGen.java
+++ b/jflex/src/test/java/jflex/core/unicode/CharClassesGen.java
@@ -122,6 +122,8 @@ public class CharClassesGen extends Generator<CharClasses> {
       }
       CharClasses next = smallest();
       next.makeClass(set, false);
+
+      assert next.invariants() : next;
       results.add(next);
     }
 

--- a/testsuite/testcases/src/test/cases/include2/skeleton.nested
+++ b/testsuite/testcases/src/test/cases/include2/skeleton.nested
@@ -36,7 +36,7 @@
 
   /** the textposition at the last accepting state */
   private int zzMarkedPos;
-  
+
   /** the current text position in the buffer */
   private int zzCurrentPos;
 
@@ -54,12 +54,12 @@
   private int yychar;
 
   /**
-   * the number of characters from the last newline up to the start of the 
+   * the number of characters from the last newline up to the start of the
    * matched text
    */
   private int yycolumn;
 
-  /** 
+  /**
    * zzAtBOL == true <=> the scanner is currently at the beginning of a line
    */
   private boolean zzAtBOL = true;
@@ -69,8 +69,8 @@
 
   /** denotes if the user-EOF-code has already been executed */
   private boolean zzEOFDone;
-  
-  /** 
+
+  /**
    * The number of occupied positions in zzBuffer beyond zzEndRead.
    * When a lead/high surrogate has been read from the input stream
    * into the final zzBuffer position, this will have a value of 1;
@@ -103,7 +103,7 @@
 
     /** sets all values stored in this class */
     ZzFlexStreamInfo(java.io.Reader zzReader, int zzEndRead, int zzStartRead,
-                  int zzCurrentPos, int zzMarkedPos, char [] zzBuffer, 
+                  int zzCurrentPos, int zzMarkedPos, char [] zzBuffer,
                   boolean zzAtBOL, boolean zzAtEOF, boolean zzEOFDone,
                   int zzFinalHighSurrogate, int yyline, int yychar, int yycolumn) {
       this.zzReader      = zzReader;
@@ -131,7 +131,7 @@
    * Refills the input buffer.
    *
    * @return      <code>false</code>, iff there was new input.
-   * 
+   *
    * @exception   java.io.IOException  if any I/O-Error occurs
    */
   private boolean zzRefill() throws java.io.IOException {
@@ -183,7 +183,7 @@
     return true;
   }
 
-    
+
   /**
    * Closes the input stream.
    */
@@ -223,11 +223,11 @@
     zzFinalHighSurrogate = 0;
     yyline = yychar = yycolumn = 0;
   }
-    
+
 
   /**
    * Closes the current input stream and continues to
-   * read from the one on top of the stream stack. 
+   * read from the one on top of the stream stack.
    *
    * @throws java.util.EmptyStackException
    *         if there is no further stream to read from.
@@ -257,7 +257,7 @@
 
 
   /**
-   * Returns true iff there are still streams left 
+   * Returns true iff there are still streams left
    * to read from on the stream stack.
    */
   public final boolean yymoreStreams() {
@@ -269,13 +269,13 @@
    * Resets the scanner to read from a new input stream.
    * Does not close the old reader.
    *
-   * All internal variables are reset, the old input stream 
+   * All internal variables are reset, the old input stream
    * <b>cannot</b> be reused (internal buffer is discarded and lost).
    * Lexical state is set to <tt>ZZ_INITIAL</tt>.
    *
    * Internal scan buffer is resized down to its initial length, if it has grown.
    *
-   * @param reader   the new input stream 
+   * @param reader   the new input stream
    *
    * @see #yypushStream(java.io.Reader)
    * @see #yypopStream()
@@ -322,12 +322,12 @@
 
 
   /**
-   * Returns the character at position <tt>pos</tt> from the 
-   * matched text. 
-   * 
+   * Returns the character at position <tt>pos</tt> from the
+   * matched text.
+   *
    * It is equivalent to yytext().charAt(pos), but faster
    *
-   * @param pos the position of the character to fetch. 
+   * @param pos the position of the character to fetch.
    *            A value from 0 to yylength()-1.
    *
    * @return the character at position pos
@@ -348,8 +348,8 @@
   /**
    * Reports an error that occured while scanning.
    *
-   * In a wellformed scanner (no or only correct usage of 
-   * yypushback(int) and a match-all fallback rule) this method 
+   * In a wellformed scanner (no or only correct usage of
+   * yypushback(int) and a match-all fallback rule) this method
    * will only be called with things that "Can't Possibly Happen".
    * If this method is called, something is seriously wrong
    * (e.g. a JFlex bug producing a faulty scanner etc.).
@@ -369,7 +369,7 @@
     }
 
 --- throws clause
-  } 
+  }
 
 
   /**
@@ -408,18 +408,17 @@
       int zzMarkedPosL = zzMarkedPos;
       int zzEndReadL = zzEndRead;
       char [] zzBufferL = zzBuffer;
-      char [] zzCMapL = ZZ_CMAP;
 
 --- start admin (line, char, col count)
       zzAction = -1;
 
       zzCurrentPosL = zzCurrentPos = zzStartRead = zzMarkedPosL;
-  
+
 --- start admin (lexstate etc)
 
       zzForAction: {
         while (true) {
-    
+
 --- next input, line, col, char count, next transition, isFinal action
             zzAction = zzState;
             zzMarkedPosL = zzCurrentPosL;

--- a/testsuite/testcases/src/test/cases/spoon-feed-reader/fixed.skeleton.default
+++ b/testsuite/testcases/src/test/cases/spoon-feed-reader/fixed.skeleton.default
@@ -149,7 +149,7 @@
     return true;
   }
 
-    
+
   /**
    * Closes the input stream.
    */
@@ -219,7 +219,7 @@
 
   /**
    * Returns the character at the given position from the matched text.
-   * 
+   *
    * <p>It is equivalent to {@code yytext().charAt(pos)}, but faster.
    *
    * @param position the position of the character to fetch. A value from 0 to {@code yylength()-1}.
@@ -262,7 +262,7 @@
     }
 
 --- throws clause
-  } 
+  }
 
 
   /**
@@ -300,7 +300,6 @@
     int zzMarkedPosL;
     int zzEndReadL = zzEndRead;
     char[] zzBufferL = zzBuffer;
-    char[] zzCMapL = ZZ_CMAP;
 
 --- local declarations
 
@@ -311,12 +310,12 @@
       zzAction = -1;
 
       zzCurrentPosL = zzCurrentPos = zzStartRead = zzMarkedPosL;
-  
+
 --- start admin (lexstate etc)
 
       zzForAction: {
         while (true) {
-    
+
 --- next input, line, col, char count, next transition, isFinal action
             zzAction = zzState;
             zzMarkedPosL = zzCurrentPosL;

--- a/testsuite/testcases/src/test/cases/spoon-feed-reader/problematic.skeleton.default
+++ b/testsuite/testcases/src/test/cases/spoon-feed-reader/problematic.skeleton.default
@@ -145,7 +145,7 @@
     return true;
   }
 
-    
+
   /**
    * Closes the input stream.
    */
@@ -215,7 +215,7 @@
 
   /**
    * Returns the character at the given position from the matched text.
-   * 
+   *
    * <p>It is equivalent to {@code yytext().charAt(pos)}, but faster.
    *
    * @param position the position of the character to fetch. A value from 0 to {@code yylength()-1}.
@@ -258,7 +258,7 @@
     }
 
 --- throws clause
-  } 
+  }
 
 
   /**
@@ -296,7 +296,6 @@
     int zzMarkedPosL;
     int zzEndReadL = zzEndRead;
     char[] zzBufferL = zzBuffer;
-    char[] zzCMapL = ZZ_CMAP;
 
 --- local declarations
 
@@ -307,12 +306,12 @@
       zzAction = -1;
 
       zzCurrentPosL = zzCurrentPos = zzStartRead = zzMarkedPosL;
-  
+
 --- start admin (lexstate etc)
 
       zzForAction: {
         while (true) {
-    
+
 --- next input, line, col, char count, next transition, isFinal action
             zzAction = zzState;
             zzMarkedPosL = zzCurrentPosL;


### PR DESCRIPTION
This addresses the memory issue #199. With more recent Unicode versions, the
character map took 0x110000 * 4 bytes, i.e. ~4MB. Most of this is never
accessed, but it still increases overall memory consumption esp for multiple
scanners.

This PR:
 * changes the current one-level array to a two-level table structure
 * adds quickcheck tests for the table construction
 * updates runtime engine to use that structure
 * updates skeleton files to remove reference to old ZZ_CMAP
 * removes trailing white space in generated template code

Typical memory consumption for the char map decreases from ~4MB to < 100KB,
for simple scanners (little unicode use > 0xFF) to ~20KB.

Even though this increases the number of operations in the innermost loop,
with a bit of luck performance might actually benefit because of better
cache locality. Benchmarking still to be done.


