### PR TITLE
upgrade fmt-maven-plugin to version 2.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -205,7 +205,7 @@
         <plugin>
           <groupId>com.coveo</groupId>
           <artifactId>fmt-maven-plugin</artifactId>
-          <version>2.5.0</version>
+          <version>2.9</version>
         </plugin>
         <plugin>
           <artifactId>maven-compiler-plugin</artifactId>
@@ -441,7 +441,7 @@
                 </goals>
               </execution>
             </executions>
-          </plugin>        
+          </plugin>
         </plugins>
       </build>
     </profile>


### PR DESCRIPTION
Version 2.5 was fighting with google-java-format 1.7 on travis