### PR TITLE
activate ant tests in examples

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,6 +61,7 @@ matrix:
 # They cannot be deleted in the before_cache phase,
 # otherwise `mvn site` fails in the before_deploy phase.
 before_install:
+- sudo apt-get -y install ant-optional
 - ./scripts/clean.sh
 
 install:

--- a/scripts/test-examples.sh
+++ b/scripts/test-examples.sh
@@ -28,8 +28,6 @@ set -e
 logi "Compile, test and install all"
 logi "============================="
 "$BASEDIR"/scripts/mvn-install-fastbuild.sh jflex-maven-plugin
-# Some tests invoke /bin/jflex which expects the jar in /lib
-cp "$BASEDIR"/jflex/target/jflex-full-*.jar "$BASEDIR"/jflex/lib
 
 cd "$BASEDIR"/jflex/examples
 
@@ -47,17 +45,13 @@ cd ..
 logi "Example: cup-interpreter"
 cd cup-interpreter
 "$MVN" test
-# TODO(#384) Fix ant test
-"$ANT" build
-# "$ANT" test
+"$ANT" test
 "$MAKE" test
 cd ..
 
 logi "Example: cup-java"
 cd cup-java
 "$MVN" test
-# Fix ant #384
-"$ANT" build
 "$ANT" test
 "$MAKE" test
 cd ..
@@ -72,10 +66,8 @@ cd ..
 logi "Example: simple"
 cd simple
 "$MVN" test
-"$ANT" build
-# Fix ant
-#"$ANT" test
-# make test
+"$ANT" test
+# "$MAKE" test
 cd ..
 
 logi "Example: standalone"


### PR DESCRIPTION
These should now build again, and cause test failure when they don't.
Also removed the cp to lib, which is now already done in the maven build to
make sure lib is always up-to-date.