### PR TITLE
Optimise cmap access; now benchmarks better than 1.7.0

### DIFF
--- a/jflex/src/main/java/jflex/core/unicode/CharClasses.java
+++ b/jflex/src/main/java/jflex/core/unicode/CharClasses.java
@@ -435,14 +435,19 @@ public class CharClasses {
 
   /**
    * Returns a two-level table structure for this char-class object. The char class of input {@code
-   * x} is {@code snd[(fst[x >> BLOCK_BITS] << BLOCK_BITS) | (x && BLOCK_MASK))]} where {@code
-   * BLOCK_MASK = BLOCK_SIZE - 1}
+   * x} is {@code snd[(fst[x >> BLOCK_BITS]) | (x && BLOCK_MASK))]} where {@code BLOCK_MASK =
+   * BLOCK_SIZE - 1}, and the index of the first block in the top level is guaranteed to be 0 (which
+   * means the {@code fst} lookup can be skipped if {@code x <= BLOCK_MASK}).
    *
    * @see CMapBlock#BLOCK_BITS
    * @see CMapBlock#BLOCK_SIZE
    */
   public Pair<int[], int[]> getTables() {
     Pair<int[], List<CMapBlock>> p = computeTables();
-    return new Pair<int[], int[]>(p.fst, flattenBlocks(p.snd));
+    int[] shifted = new int[p.fst.length];
+    for (int i = 0; i < p.fst.length; i++) {
+      shifted[i] = p.fst[i] << CMapBlock.BLOCK_BITS;
+    }
+    return new Pair<int[], int[]>(shifted, flattenBlocks(p.snd));
   }
 }

--- a/jflex/src/main/java/jflex/generator/Emitter.java
+++ b/jflex/src/main/java/jflex/generator/Emitter.java
@@ -959,11 +959,10 @@ public final class Emitter {
       println("    return ZZ_CMAP[input];");
     } else {
       println("    int offset = input & " + (CMapBlock.BLOCK_SIZE - 1) + ";");
-      println("    int top = input >> " + CMapBlock.BLOCK_BITS + ";");
       println(
-          "    return ZZ_CMAP_BLOCKS[(ZZ_CMAP_TOP[top] << "
+          "    return offset == input ? ZZ_CMAP_BLOCKS[offset] : ZZ_CMAP_BLOCKS[ZZ_CMAP_TOP[input >> "
               + CMapBlock.BLOCK_BITS
-              + ") | offset];");
+              + "] | offset];");
     }
     println("  }");
   }

--- a/jflex/src/test/java/jflex/core/unicode/CharClassesQuickcheck.java
+++ b/jflex/src/test/java/jflex/core/unicode/CharClassesQuickcheck.java
@@ -160,7 +160,7 @@ public class CharClassesQuickcheck {
   private static int translateFlat(Pair<int[], int[]> table, int input) {
     int top = table.fst[input >> CMapBlock.BLOCK_BITS];
     int offset = input & (CMapBlock.BLOCK_SIZE - 1);
-    return table.snd[(top << CMapBlock.BLOCK_BITS) | offset];
+    return offset == input ? table.snd[offset] : table.snd[top | offset];
   }
 
   @Property(trials = 20)


### PR DESCRIPTION
 * avoid one array access for the frequent case of input <= BLOCK_SIZE
 * pre-compute the shift by BLOCK_SIZE

Current benchmark data is consistently faster (steady state and cold startup)
than 1.7.0 for inputs with characters <= 255.
