### PR TITLE
address more warnings

### DIFF
--- a/javatests/jflex/testcase/include/IncludeGoldenTest.java
+++ b/javatests/jflex/testcase/include/IncludeGoldenTest.java
@@ -36,7 +36,7 @@ public class IncludeGoldenTest extends AbstractGoldenTest {
     compareSystemOutWith(golden);
 
     IncludeScanner scanner = scannerFactory.createScannerForFile(golden.inputFile);
-    while (!scanner.isAtEof()) {
+    while (!scanner.yyatEOF()) {
       System.out.println(scanner.yylex());
     }
   }

--- a/javatests/jflex/testcase/include/skeleton.nested
+++ b/javatests/jflex/testcase/include/skeleton.nested
@@ -47,28 +47,11 @@
       from input */
   private int zzEndRead;
 
-  /** number of newlines encountered up to the start of the matched text */
-  private int yyline;
-
-  /** the number of characters up to the start of the matched text */
-  private int yychar;
-
   /**
-   * the number of characters from the last newline up to the start of the
-   * matched text
+   * Whether the scanner is at the end of file.
+   * @see #yyatEOF
    */
-  private int yycolumn;
-
-  /**
-   * zzAtBOL == true <=> the scanner is currently at the beginning of a line
-   */
-  private boolean zzAtBOL = true;
-
-  /** zzAtEOF == true <=> the scanner is at the EOF */
   private boolean zzAtEOF;
-
-  /** denotes if the user-EOF-code has already been executed */
-  private boolean zzEOFDone;
 
   /**
    * The number of occupied positions in zzBuffer beyond zzEndRead.
@@ -93,7 +76,7 @@
     int zzCurrentPos;
     int zzMarkedPos;
     int yyline;
-    int yychar;
+    long yychar;
     int yycolumn;
     char [] zzBuffer;
     boolean zzAtBOL;
@@ -105,7 +88,8 @@
     ZzFlexStreamInfo(java.io.Reader zzReader, int zzEndRead, int zzStartRead,
                   int zzCurrentPos, int zzMarkedPos, char [] zzBuffer,
                   boolean zzAtBOL, boolean zzAtEOF, boolean zzEOFDone,
-                  int zzFinalHighSurrogate, int yyline, int yychar, int yycolumn) {
+                  int zzFinalHighSurrogate, int yyline, long yychar,
+                  int yycolumn) {
       this.zzReader      = zzReader;
       this.zzEndRead     = zzEndRead;
       this.zzStartRead   = zzStartRead;
@@ -165,31 +149,41 @@
     int requested = zzBuffer.length - zzEndRead;
     int numRead = zzReader.read(zzBuffer, zzEndRead, requested);
 
-    // unlikely but not impossible: read 0 characters, but not at end of stream
+    /* not supposed to occur according to specification of java.io.Reader */
     if (numRead == 0) {
-      numRead = zzReader.read(zzBuffer, zzEndRead, requested);
+      throw new java.io.IOException("Reader returned 0 characters. See JFlex examples for workaround.");
     }
     if (numRead > 0) {
       zzEndRead += numRead;
-      if (numRead == requested) { /* possibly more input available */
-        if (Character.isHighSurrogate(zzBuffer[zzEndRead - 1])) {
+      if (Character.isHighSurrogate(zzBuffer[zzEndRead - 1])) {
+        if (numRead == requested) { // We requested too few chars to encode a full Unicode character
           --zzEndRead;
           zzFinalHighSurrogate = 1;
+        } else {                    // There is room in the buffer for at least one more char
+          int c = zzReader.read();  // Expecting to read a paired low surrogate char
+          if (c == -1) {
+            return true;
+          } else {
+            zzBuffer[zzEndRead++] = (char)c;
+          }
         }
       }
+      /* potentially more input available */
       return false;
     }
 
+    /* numRead < 0 ==> end of stream */
     return true;
   }
 
-
   /**
-   * Closes the input stream.
+   * Closes the input reader.
+   *
+   * @throws java.io.IOException if the reader could not be closed.
    */
   public final void yyclose() throws java.io.IOException {
-    zzAtEOF = true;            /* indicate end of file */
-    zzEndRead = zzStartRead;  /* invalidate buffer    */
+    zzAtEOF = true;           // indicate end of file
+    zzEndRead = zzStartRead;  // invalidate buffer
 
     if (zzReader != null)
       zzReader.close();
@@ -214,14 +208,9 @@
                         zzMarkedPos, zzBuffer, zzAtBOL, zzAtEOF, zzEOFDone,
                         zzFinalHighSurrogate, yyline, yychar, yycolumn)
     );
-    zzAtBOL  = true;
-    zzAtEOF  = false;
     zzBuffer = new char[ZZ_BUFFERSIZE];
     zzReader = reader;
-    zzEndRead = zzStartRead = 0;
-    zzCurrentPos = zzMarkedPos = 0;
-    zzFinalHighSurrogate = 0;
-    yyline = yychar = yycolumn = 0;
+    yyResetPosition();
   }
 
 
@@ -271,7 +260,7 @@
    *
    * All internal variables are reset, the old input stream
    * <b>cannot</b> be reused (internal buffer is discarded and lost).
-   * Lexical state is set to <tt>ZZ_INITIAL</tt>.
+   * Lexical state is set to {@code ZZ_INITIAL}.
    *
    * Internal scan buffer is resized down to its initial length, if it has grown.
    *
@@ -282,33 +271,49 @@
    */
   public final void yyreset(java.io.Reader reader) {
     zzReader = reader;
-    zzAtBOL  = true;
-    zzAtEOF  = false;
     zzEOFDone = false;
-    zzEndRead = zzStartRead = 0;
-    zzCurrentPos = zzMarkedPos = 0;
-    zzFinalHighSurrogate = 0;
-    yyline = yychar = yycolumn = 0;
+    yyResetPosition();
     zzLexicalState = YYINITIAL;
-    if (zzBuffer.length > ZZ_BUFFERSIZE)
+    if (zzBuffer.length > ZZ_BUFFERSIZE) {
       zzBuffer = new char[ZZ_BUFFERSIZE];
+    }
+  }
+
+  /**
+   * Resets the input position.
+   */
+  private final void yyResetPosition() {
+      zzAtBOL  = true;
+      zzAtEOF  = false;
+      zzCurrentPos = 0;
+      zzMarkedPos = 0;
+      zzStartRead = 0;
+      zzEndRead = 0;
+      zzFinalHighSurrogate = 0;
+      yyline = 0;
+      yycolumn = 0;
+      yychar = 0L;
+  }
+
+  /**
+   * Returns whether the scanner has reached the end of the reader it reads from.
+   *
+   * @return whether the scanner has reached EOF.
+   */
+  public final boolean yyatEOF() {
+    return zzAtEOF;
   }
 
 
   /**
    * Returns the current lexical state.
+   *
+   * @return the current lexical state.
    */
   public final int yystate() {
     return zzLexicalState;
   }
 
-
-  /**
-   * Returns whether the scanner has reached the end of the reader it reads from.
-   */
-  public final boolean isAtEof() {
-    return zzAtEOF;
-  }
 
   /**
    * Enters a new lexical state
@@ -322,6 +327,8 @@
 
   /**
    * Returns the text matched by the current regular expression.
+   *
+   * @return the matched text.
    */
   public final String yytext() {
     return new String( zzBuffer, zzStartRead, zzMarkedPos-zzStartRead );
@@ -329,7 +336,7 @@
 
 
   /**
-   * Returns the character at position <tt>pos</tt> from the
+   * Returns the character at position {@code pos} from the
    * matched text.
    *
    * It is equivalent to yytext().charAt(pos), but faster
@@ -345,7 +352,9 @@
 
 
   /**
-   * Returns the length of the matched text region.
+   * How many characters were matched.
+   *
+   * @return the length of the matched text region.
    */
   public final int yylength() {
     return zzMarkedPos-zzStartRead;

--- a/javatests/jflex/testcase/include2/skeleton.nested
+++ b/javatests/jflex/testcase/include2/skeleton.nested
@@ -47,28 +47,11 @@
       from input */
   private int zzEndRead;
 
-  /** number of newlines encountered up to the start of the matched text */
-  private int yyline;
-
-  /** the number of characters up to the start of the matched text */
-  private int yychar;
-
   /**
-   * the number of characters from the last newline up to the start of the
-   * matched text
+   * Whether the scanner is at the end of file.
+   * @see #yyatEOF
    */
-  private int yycolumn;
-
-  /**
-   * zzAtBOL == true <=> the scanner is currently at the beginning of a line
-   */
-  private boolean zzAtBOL = true;
-
-  /** zzAtEOF == true <=> the scanner is at the EOF */
   private boolean zzAtEOF;
-
-  /** denotes if the user-EOF-code has already been executed */
-  private boolean zzEOFDone;
 
   /**
    * The number of occupied positions in zzBuffer beyond zzEndRead.
@@ -93,7 +76,7 @@
     int zzCurrentPos;
     int zzMarkedPos;
     int yyline;
-    int yychar;
+    long yychar;
     int yycolumn;
     char [] zzBuffer;
     boolean zzAtBOL;
@@ -105,7 +88,8 @@
     ZzFlexStreamInfo(java.io.Reader zzReader, int zzEndRead, int zzStartRead,
                   int zzCurrentPos, int zzMarkedPos, char [] zzBuffer,
                   boolean zzAtBOL, boolean zzAtEOF, boolean zzEOFDone,
-                  int zzFinalHighSurrogate, int yyline, int yychar, int yycolumn) {
+                  int zzFinalHighSurrogate, int yyline, long yychar,
+                  int yycolumn) {
       this.zzReader      = zzReader;
       this.zzEndRead     = zzEndRead;
       this.zzStartRead   = zzStartRead;
@@ -165,31 +149,41 @@
     int requested = zzBuffer.length - zzEndRead;
     int numRead = zzReader.read(zzBuffer, zzEndRead, requested);
 
-    // unlikely but not impossible: read 0 characters, but not at end of stream
+    /* not supposed to occur according to specification of java.io.Reader */
     if (numRead == 0) {
-      numRead = zzReader.read(zzBuffer, zzEndRead, requested);
+      throw new java.io.IOException("Reader returned 0 characters. See JFlex examples for workaround.");
     }
     if (numRead > 0) {
       zzEndRead += numRead;
-      if (numRead == requested) { /* possibly more input available */
-        if (Character.isHighSurrogate(zzBuffer[zzEndRead - 1])) {
+      if (Character.isHighSurrogate(zzBuffer[zzEndRead - 1])) {
+        if (numRead == requested) { // We requested too few chars to encode a full Unicode character
           --zzEndRead;
           zzFinalHighSurrogate = 1;
+        } else {                    // There is room in the buffer for at least one more char
+          int c = zzReader.read();  // Expecting to read a paired low surrogate char
+          if (c == -1) {
+            return true;
+          } else {
+            zzBuffer[zzEndRead++] = (char)c;
+          }
         }
       }
+      /* potentially more input available */
       return false;
     }
 
+    /* numRead < 0 ==> end of stream */
     return true;
   }
 
-
   /**
-   * Closes the input stream.
+   * Closes the input reader.
+   *
+   * @throws java.io.IOException if the reader could not be closed.
    */
   public final void yyclose() throws java.io.IOException {
-    zzAtEOF = true;            /* indicate end of file */
-    zzEndRead = zzStartRead;  /* invalidate buffer    */
+    zzAtEOF = true;           // indicate end of file
+    zzEndRead = zzStartRead;  // invalidate buffer
 
     if (zzReader != null)
       zzReader.close();
@@ -214,14 +208,9 @@
                         zzMarkedPos, zzBuffer, zzAtBOL, zzAtEOF, zzEOFDone,
                         zzFinalHighSurrogate, yyline, yychar, yycolumn)
     );
-    zzAtBOL  = true;
-    zzAtEOF  = false;
     zzBuffer = new char[ZZ_BUFFERSIZE];
     zzReader = reader;
-    zzEndRead = zzStartRead = 0;
-    zzCurrentPos = zzMarkedPos = 0;
-    zzFinalHighSurrogate = 0;
-    yyline = yychar = yycolumn = 0;
+    yyResetPosition();
   }
 
 
@@ -271,7 +260,7 @@
    *
    * All internal variables are reset, the old input stream
    * <b>cannot</b> be reused (internal buffer is discarded and lost).
-   * Lexical state is set to <tt>ZZ_INITIAL</tt>.
+   * Lexical state is set to {@code ZZ_INITIAL}.
    *
    * Internal scan buffer is resized down to its initial length, if it has grown.
    *
@@ -282,32 +271,49 @@
    */
   public final void yyreset(java.io.Reader reader) {
     zzReader = reader;
-    zzAtBOL  = true;
-    zzAtEOF  = false;
     zzEOFDone = false;
-    zzEndRead = zzStartRead = 0;
-    zzCurrentPos = zzMarkedPos = 0;
-    zzFinalHighSurrogate = 0;
-    yyline = yychar = yycolumn = 0;
+    yyResetPosition();
     zzLexicalState = YYINITIAL;
-    if (zzBuffer.length > ZZ_BUFFERSIZE)
+    if (zzBuffer.length > ZZ_BUFFERSIZE) {
       zzBuffer = new char[ZZ_BUFFERSIZE];
+    }
+  }
+
+  /**
+   * Resets the input position.
+   */
+  private final void yyResetPosition() {
+      zzAtBOL  = true;
+      zzAtEOF  = false;
+      zzCurrentPos = 0;
+      zzMarkedPos = 0;
+      zzStartRead = 0;
+      zzEndRead = 0;
+      zzFinalHighSurrogate = 0;
+      yyline = 0;
+      yycolumn = 0;
+      yychar = 0L;
+  }
+
+  /**
+   * Returns whether the scanner has reached the end of the reader it reads from.
+   *
+   * @return whether the scanner has reached EOF.
+   */
+  public final boolean yyatEOF() {
+    return zzAtEOF;
   }
 
 
   /**
    * Returns the current lexical state.
+   *
+   * @return the current lexical state.
    */
   public final int yystate() {
     return zzLexicalState;
   }
 
-  /**
-   * Returns whether the scanner has reached the end of the reader it reads from.
-   */
-  public final boolean yyatEOF() {
-    return zzAtEOF;
-  }
 
   /**
    * Enters a new lexical state
@@ -321,6 +327,8 @@
 
   /**
    * Returns the text matched by the current regular expression.
+   *
+   * @return the matched text.
    */
   public final String yytext() {
     return new String( zzBuffer, zzStartRead, zzMarkedPos-zzStartRead );
@@ -328,7 +336,7 @@
 
 
   /**
-   * Returns the character at position <tt>pos</tt> from the
+   * Returns the character at position {@code pos} from the
    * matched text.
    *
    * It is equivalent to yytext().charAt(pos), but faster
@@ -344,7 +352,9 @@
 
 
   /**
-   * Returns the length of the matched text region.
+   * How many characters were matched.
+   *
+   * @return the length of the matched text region.
    */
   public final int yylength() {
     return zzMarkedPos-zzStartRead;

--- a/jflex/src/main/java/jflex/generator/Emitter.java
+++ b/jflex/src/main/java/jflex/generator/Emitter.java
@@ -1291,6 +1291,49 @@ public final class Emitter {
     }
   }
 
+  /**
+   * Emit {@code yychar}, {@code yycolumn}, {@code zzAtBOL}, {@code zzEOFDone} with warning
+   * suppression when needed.
+   */
+  private void emitVarDefs() {
+    // We can't leave out these declarations completely, even if unused, because
+    // the reset functions in the skeleton refer to them. They are written to,
+    // but not read. Only other option would be to pull these out of the skeleton
+    // as well.
+
+    println("  /** Number of newlines encountered up to the start of the matched text. */");
+    if (!scanner.lineCount()) {
+      println("  @SuppressWarnings(\"unused\")");
+    }
+    println("  private int yyline;");
+    println();
+    println(
+        "  /** Number of characters from the last newline up to the start of the matched text. */");
+    if (!scanner.columnCount()) {
+      println("  @SuppressWarnings(\"unused\")");
+    }
+    println("  private int yycolumn;");
+    println();
+    println("  /** Number of characters up to the start of the matched text. */");
+    if (!scanner.charCount()) {
+      println("  @SuppressWarnings(\"unused\")");
+    }
+    println("  private long yychar;");
+    println();
+    println("  /** Whether the scanner is currently at the beginning of a line. */");
+    if (!scanner.bolUsed()) {
+      println("  @SuppressWarnings(\"unused\")");
+    }
+    println("  private boolean zzAtBOL = true;");
+    println();
+    println("  /** Whether the user-EOF-code has already been executed. */");
+    if (eofCode == null) {
+      println("  @SuppressWarnings(\"unused\")");
+    }
+    println("  private boolean zzEOFDone;");
+    println();
+  }
+
   /** Main Emitter method. */
   public void emit() {
     String functionName = (scanner.functionName() != null) ? scanner.functionName() : "yylex";
@@ -1333,6 +1376,8 @@ public final class Emitter {
     skel.emitNext();
 
     emitLookBuffer();
+
+    emitVarDefs();
 
     emitClassCode();
 

--- a/jflex/src/main/jflex/skeleton.nested-1.8.0
+++ b/jflex/src/main/jflex/skeleton.nested-1.8.0
@@ -47,31 +47,11 @@
       from input */
   private int zzEndRead;
 
-  /** number of newlines encountered up to the start of the matched text */
-  private int yyline;
-
-  /** the number of characters up to the start of the matched text */
-  private long yychar;
-
-  /**
-   * the number of characters from the last newline up to the start of the
-   * matched text
-   */
-  private int yycolumn;
-
-  /**
-   * zzAtBOL == true iff the scanner is currently at the beginning of a line
-   */
-  private boolean zzAtBOL = true;
-
   /**
    * Whether the scanner is at the end of file.
    * @see #yyatEOF
    */
   private boolean zzAtEOF;
-
-  /** denotes if the user-EOF-code has already been executed */
-  private boolean zzEOFDone;
 
   /**
    * The number of occupied positions in zzBuffer beyond zzEndRead.

--- a/jflex/src/main/resources/jflex/skeleton.default
+++ b/jflex/src/main/resources/jflex/skeleton.default
@@ -53,26 +53,11 @@
   /** Marks the last character in the buffer, that has been read from input. */
   private int zzEndRead;
 
-  /** Number of newlines encountered up to the start of the matched text. */
-  private int yyline;
-
-  /** Number of characters up to the start of the matched text. */
-  private long yychar;
-
-  /** Number of characters from the last newline up to the start of the matched text. */
-  private int yycolumn;
-
-  /** Whether the scanner is currently at the beginning of a line. */
-  private boolean zzAtBOL = true;
-
   /**
    * Whether the scanner is at the end of file.
    * @see #yyatEOF
    */
   private boolean zzAtEOF;
-
-  /** Whether the user-EOF-code has already been executed. */
-  private boolean zzEOFDone;
 
   /**
    * The number of occupied positions in {@link #zzBuffer} beyond {@link #zzEndRead}.

--- a/jflex/src/test/java/jflex/chars/IntervalGen.java
+++ b/jflex/src/test/java/jflex/chars/IntervalGen.java
@@ -30,7 +30,7 @@ public class IntervalGen extends Generator<Interval> {
   private int maxChar = 50;
 
   /** How often to return single-character intervals. */
-  private float singleCharRatio = 0.2f;
+  private final float singleCharRatio = 0.2f;
 
   /** Constructs and registers generator for Interval */
   public IntervalGen() {

--- a/jflex/src/test/java/jflex/core/unicode/CharClassesGen.java
+++ b/jflex/src/test/java/jflex/core/unicode/CharClassesGen.java
@@ -36,7 +36,7 @@ public class CharClassesGen extends Generator<CharClasses> {
   private int maxSize = 5;
 
   /** Generator for classes (= IntCharSet) */
-  private IntCharSetGen classGen;
+  private final IntCharSetGen classGen;
 
   /** The UnicodeProperties that determine maxCharCode and getCaseless */
   // TODO(lsf): make UnicodeProperties a configurable option, return something useful

--- a/jflex/src/test/java/jflex/core/unicode/IntCharSetGen.java
+++ b/jflex/src/test/java/jflex/core/unicode/IntCharSetGen.java
@@ -31,7 +31,7 @@ public class IntCharSetGen extends Generator<IntCharSet> {
   private int maxSize = 5;
 
   /** Generator for Intervals */
-  private IntervalGen intervals;
+  private final IntervalGen intervals;
 
   /** Constructs generator for IntCharSet */
   public IntCharSetGen() {

--- a/testsuite/testcases/src/test/cases/include/skeleton.nested
+++ b/testsuite/testcases/src/test/cases/include/skeleton.nested
@@ -47,28 +47,11 @@
       from input */
   private int zzEndRead;
 
-  /** number of newlines encountered up to the start of the matched text */
-  private int yyline;
-
-  /** the number of characters up to the start of the matched text */
-  private int yychar;
-
   /**
-   * the number of characters from the last newline up to the start of the
-   * matched text
+   * Whether the scanner is at the end of file.
+   * @see #yyatEOF
    */
-  private int yycolumn;
-
-  /**
-   * zzAtBOL == true <=> the scanner is currently at the beginning of a line
-   */
-  private boolean zzAtBOL = true;
-
-  /** zzAtEOF == true <=> the scanner is at the EOF */
   private boolean zzAtEOF;
-
-  /** denotes if the user-EOF-code has already been executed */
-  private boolean zzEOFDone;
 
   /**
    * The number of occupied positions in zzBuffer beyond zzEndRead.
@@ -93,7 +76,7 @@
     int zzCurrentPos;
     int zzMarkedPos;
     int yyline;
-    int yychar;
+    long yychar;
     int yycolumn;
     char [] zzBuffer;
     boolean zzAtBOL;
@@ -105,7 +88,8 @@
     ZzFlexStreamInfo(java.io.Reader zzReader, int zzEndRead, int zzStartRead,
                   int zzCurrentPos, int zzMarkedPos, char [] zzBuffer,
                   boolean zzAtBOL, boolean zzAtEOF, boolean zzEOFDone,
-                  int zzFinalHighSurrogate, int yyline, int yychar, int yycolumn) {
+                  int zzFinalHighSurrogate, int yyline, long yychar,
+                  int yycolumn) {
       this.zzReader      = zzReader;
       this.zzEndRead     = zzEndRead;
       this.zzStartRead   = zzStartRead;
@@ -165,31 +149,41 @@
     int requested = zzBuffer.length - zzEndRead;
     int numRead = zzReader.read(zzBuffer, zzEndRead, requested);
 
-    // unlikely but not impossible: read 0 characters, but not at end of stream
+    /* not supposed to occur according to specification of java.io.Reader */
     if (numRead == 0) {
-      numRead = zzReader.read(zzBuffer, zzEndRead, requested);
+      throw new java.io.IOException("Reader returned 0 characters. See JFlex examples for workaround.");
     }
     if (numRead > 0) {
       zzEndRead += numRead;
-      if (numRead == requested) { /* possibly more input available */
-        if (Character.isHighSurrogate(zzBuffer[zzEndRead - 1])) {
+      if (Character.isHighSurrogate(zzBuffer[zzEndRead - 1])) {
+        if (numRead == requested) { // We requested too few chars to encode a full Unicode character
           --zzEndRead;
           zzFinalHighSurrogate = 1;
+        } else {                    // There is room in the buffer for at least one more char
+          int c = zzReader.read();  // Expecting to read a paired low surrogate char
+          if (c == -1) {
+            return true;
+          } else {
+            zzBuffer[zzEndRead++] = (char)c;
+          }
         }
       }
+      /* potentially more input available */
       return false;
     }
 
+    /* numRead < 0 ==> end of stream */
     return true;
   }
 
-
   /**
-   * Closes the input stream.
+   * Closes the input reader.
+   *
+   * @throws java.io.IOException if the reader could not be closed.
    */
   public final void yyclose() throws java.io.IOException {
-    zzAtEOF = true;            /* indicate end of file */
-    zzEndRead = zzStartRead;  /* invalidate buffer    */
+    zzAtEOF = true;           // indicate end of file
+    zzEndRead = zzStartRead;  // invalidate buffer
 
     if (zzReader != null)
       zzReader.close();
@@ -214,14 +208,9 @@
                         zzMarkedPos, zzBuffer, zzAtBOL, zzAtEOF, zzEOFDone,
                         zzFinalHighSurrogate, yyline, yychar, yycolumn)
     );
-    zzAtBOL  = true;
-    zzAtEOF  = false;
     zzBuffer = new char[ZZ_BUFFERSIZE];
     zzReader = reader;
-    zzEndRead = zzStartRead = 0;
-    zzCurrentPos = zzMarkedPos = 0;
-    zzFinalHighSurrogate = 0;
-    yyline = yychar = yycolumn = 0;
+    yyResetPosition();
   }
 
 
@@ -271,7 +260,7 @@
    *
    * All internal variables are reset, the old input stream
    * <b>cannot</b> be reused (internal buffer is discarded and lost).
-   * Lexical state is set to <tt>ZZ_INITIAL</tt>.
+   * Lexical state is set to {@code ZZ_INITIAL}.
    *
    * Internal scan buffer is resized down to its initial length, if it has grown.
    *
@@ -282,21 +271,44 @@
    */
   public final void yyreset(java.io.Reader reader) {
     zzReader = reader;
-    zzAtBOL  = true;
-    zzAtEOF  = false;
     zzEOFDone = false;
-    zzEndRead = zzStartRead = 0;
-    zzCurrentPos = zzMarkedPos = 0;
-    zzFinalHighSurrogate = 0;
-    yyline = yychar = yycolumn = 0;
+    yyResetPosition();
     zzLexicalState = YYINITIAL;
-    if (zzBuffer.length > ZZ_BUFFERSIZE)
+    if (zzBuffer.length > ZZ_BUFFERSIZE) {
       zzBuffer = new char[ZZ_BUFFERSIZE];
+    }
+  }
+
+  /**
+   * Resets the input position.
+   */
+  private final void yyResetPosition() {
+      zzAtBOL  = true;
+      zzAtEOF  = false;
+      zzCurrentPos = 0;
+      zzMarkedPos = 0;
+      zzStartRead = 0;
+      zzEndRead = 0;
+      zzFinalHighSurrogate = 0;
+      yyline = 0;
+      yycolumn = 0;
+      yychar = 0L;
+  }
+
+  /**
+   * Returns whether the scanner has reached the end of the reader it reads from.
+   *
+   * @return whether the scanner has reached EOF.
+   */
+  public final boolean yyatEOF() {
+    return zzAtEOF;
   }
 
 
   /**
    * Returns the current lexical state.
+   *
+   * @return the current lexical state.
    */
   public final int yystate() {
     return zzLexicalState;
@@ -315,6 +327,8 @@
 
   /**
    * Returns the text matched by the current regular expression.
+   *
+   * @return the matched text.
    */
   public final String yytext() {
     return new String( zzBuffer, zzStartRead, zzMarkedPos-zzStartRead );
@@ -322,7 +336,7 @@
 
 
   /**
-   * Returns the character at position <tt>pos</tt> from the
+   * Returns the character at position {@code pos} from the
    * matched text.
    *
    * It is equivalent to yytext().charAt(pos), but faster
@@ -338,7 +352,9 @@
 
 
   /**
-   * Returns the length of the matched text region.
+   * How many characters were matched.
+   *
+   * @return the length of the matched text region.
    */
   public final int yylength() {
     return zzMarkedPos-zzStartRead;

--- a/testsuite/testcases/src/test/cases/include2/skeleton.nested
+++ b/testsuite/testcases/src/test/cases/include2/skeleton.nested
@@ -47,28 +47,11 @@
       from input */
   private int zzEndRead;
 
-  /** number of newlines encountered up to the start of the matched text */
-  private int yyline;
-
-  /** the number of characters up to the start of the matched text */
-  private int yychar;
-
   /**
-   * the number of characters from the last newline up to the start of the
-   * matched text
+   * Whether the scanner is at the end of file.
+   * @see #yyatEOF
    */
-  private int yycolumn;
-
-  /**
-   * zzAtBOL == true <=> the scanner is currently at the beginning of a line
-   */
-  private boolean zzAtBOL = true;
-
-  /** zzAtEOF == true <=> the scanner is at the EOF */
   private boolean zzAtEOF;
-
-  /** denotes if the user-EOF-code has already been executed */
-  private boolean zzEOFDone;
 
   /**
    * The number of occupied positions in zzBuffer beyond zzEndRead.
@@ -93,7 +76,7 @@
     int zzCurrentPos;
     int zzMarkedPos;
     int yyline;
-    int yychar;
+    long yychar;
     int yycolumn;
     char [] zzBuffer;
     boolean zzAtBOL;
@@ -105,7 +88,8 @@
     ZzFlexStreamInfo(java.io.Reader zzReader, int zzEndRead, int zzStartRead,
                   int zzCurrentPos, int zzMarkedPos, char [] zzBuffer,
                   boolean zzAtBOL, boolean zzAtEOF, boolean zzEOFDone,
-                  int zzFinalHighSurrogate, int yyline, int yychar, int yycolumn) {
+                  int zzFinalHighSurrogate, int yyline, long yychar,
+                  int yycolumn) {
       this.zzReader      = zzReader;
       this.zzEndRead     = zzEndRead;
       this.zzStartRead   = zzStartRead;
@@ -165,31 +149,41 @@
     int requested = zzBuffer.length - zzEndRead;
     int numRead = zzReader.read(zzBuffer, zzEndRead, requested);
 
-    // unlikely but not impossible: read 0 characters, but not at end of stream
+    /* not supposed to occur according to specification of java.io.Reader */
     if (numRead == 0) {
-      numRead = zzReader.read(zzBuffer, zzEndRead, requested);
+      throw new java.io.IOException("Reader returned 0 characters. See JFlex examples for workaround.");
     }
     if (numRead > 0) {
       zzEndRead += numRead;
-      if (numRead == requested) { /* possibly more input available */
-        if (Character.isHighSurrogate(zzBuffer[zzEndRead - 1])) {
+      if (Character.isHighSurrogate(zzBuffer[zzEndRead - 1])) {
+        if (numRead == requested) { // We requested too few chars to encode a full Unicode character
           --zzEndRead;
           zzFinalHighSurrogate = 1;
+        } else {                    // There is room in the buffer for at least one more char
+          int c = zzReader.read();  // Expecting to read a paired low surrogate char
+          if (c == -1) {
+            return true;
+          } else {
+            zzBuffer[zzEndRead++] = (char)c;
+          }
         }
       }
+      /* potentially more input available */
       return false;
     }
 
+    /* numRead < 0 ==> end of stream */
     return true;
   }
 
-
   /**
-   * Closes the input stream.
+   * Closes the input reader.
+   *
+   * @throws java.io.IOException if the reader could not be closed.
    */
   public final void yyclose() throws java.io.IOException {
-    zzAtEOF = true;            /* indicate end of file */
-    zzEndRead = zzStartRead;  /* invalidate buffer    */
+    zzAtEOF = true;           // indicate end of file
+    zzEndRead = zzStartRead;  // invalidate buffer
 
     if (zzReader != null)
       zzReader.close();
@@ -214,14 +208,9 @@
                         zzMarkedPos, zzBuffer, zzAtBOL, zzAtEOF, zzEOFDone,
                         zzFinalHighSurrogate, yyline, yychar, yycolumn)
     );
-    zzAtBOL  = true;
-    zzAtEOF  = false;
     zzBuffer = new char[ZZ_BUFFERSIZE];
     zzReader = reader;
-    zzEndRead = zzStartRead = 0;
-    zzCurrentPos = zzMarkedPos = 0;
-    zzFinalHighSurrogate = 0;
-    yyline = yychar = yycolumn = 0;
+    yyResetPosition();
   }
 
 
@@ -271,7 +260,7 @@
    *
    * All internal variables are reset, the old input stream
    * <b>cannot</b> be reused (internal buffer is discarded and lost).
-   * Lexical state is set to <tt>ZZ_INITIAL</tt>.
+   * Lexical state is set to {@code ZZ_INITIAL}.
    *
    * Internal scan buffer is resized down to its initial length, if it has grown.
    *
@@ -282,21 +271,44 @@
    */
   public final void yyreset(java.io.Reader reader) {
     zzReader = reader;
-    zzAtBOL  = true;
-    zzAtEOF  = false;
     zzEOFDone = false;
-    zzEndRead = zzStartRead = 0;
-    zzCurrentPos = zzMarkedPos = 0;
-    zzFinalHighSurrogate = 0;
-    yyline = yychar = yycolumn = 0;
+    yyResetPosition();
     zzLexicalState = YYINITIAL;
-    if (zzBuffer.length > ZZ_BUFFERSIZE)
+    if (zzBuffer.length > ZZ_BUFFERSIZE) {
       zzBuffer = new char[ZZ_BUFFERSIZE];
+    }
+  }
+
+  /**
+   * Resets the input position.
+   */
+  private final void yyResetPosition() {
+      zzAtBOL  = true;
+      zzAtEOF  = false;
+      zzCurrentPos = 0;
+      zzMarkedPos = 0;
+      zzStartRead = 0;
+      zzEndRead = 0;
+      zzFinalHighSurrogate = 0;
+      yyline = 0;
+      yycolumn = 0;
+      yychar = 0L;
+  }
+
+  /**
+   * Returns whether the scanner has reached the end of the reader it reads from.
+   *
+   * @return whether the scanner has reached EOF.
+   */
+  public final boolean yyatEOF() {
+    return zzAtEOF;
   }
 
 
   /**
    * Returns the current lexical state.
+   *
+   * @return the current lexical state.
    */
   public final int yystate() {
     return zzLexicalState;
@@ -315,6 +327,8 @@
 
   /**
    * Returns the text matched by the current regular expression.
+   *
+   * @return the matched text.
    */
   public final String yytext() {
     return new String( zzBuffer, zzStartRead, zzMarkedPos-zzStartRead );
@@ -322,7 +336,7 @@
 
 
   /**
-   * Returns the character at position <tt>pos</tt> from the
+   * Returns the character at position {@code pos} from the
    * matched text.
    *
    * It is equivalent to yytext().charAt(pos), but faster
@@ -338,7 +352,9 @@
 
 
   /**
-   * Returns the length of the matched text region.
+   * How many characters were matched.
+   *
+   * @return the length of the matched text region.
    */
   public final int yylength() {
     return zzMarkedPos-zzStartRead;

--- a/testsuite/testcases/src/test/cases/spoon-feed-reader/fixed.skeleton.default
+++ b/testsuite/testcases/src/test/cases/spoon-feed-reader/fixed.skeleton.default
@@ -53,23 +53,11 @@
   /** Marks the last character in the buffer, that has been read from input. */
   private int zzEndRead;
 
-  /** Number of newlines encountered up to the start of the matched text. */
-  private int yyline;
-
-  /** Number of characters up to the start of the matched text. */
-  private int yychar;
-
-  /** Number of characters from the last newline up to the start of the matched text. */
-  private int yycolumn;
-
-  /** Whether the scanner is currently at the beginning of a line. */
-  private boolean zzAtBOL = true;
-
-  /** Whether the scanner is at the end of line. */
+  /**
+   * Whether the scanner is at the end of file.
+   * @see #yyatEOF
+   */
   private boolean zzAtEOF;
-
-  /** Whether the user-EOF-code has already been executed. */
-  private boolean zzEOFDone;
 
   /**
    * The number of occupied positions in {@link #zzBuffer} beyond {@link #zzEndRead}.
@@ -82,7 +70,6 @@
 --- user class code
 
 --- constructor declaration
-
 
   /**
    * Refills the input buffer.
@@ -151,7 +138,9 @@
 
 
   /**
-   * Closes the input stream.
+   * Closes the input reader.
+   *
+   * @throws java.io.IOException if the reader could not be closed.
    */
   public final void yyclose() throws java.io.IOException {
     zzAtEOF = true; // indicate end of file
@@ -177,22 +166,45 @@
    */
   public final void yyreset(java.io.Reader reader) {
     zzReader = reader;
-    zzAtBOL = true;
-    zzAtEOF = false;
     zzEOFDone = false;
-    zzEndRead = zzStartRead = 0;
-    zzCurrentPos = zzMarkedPos = 0;
-    zzFinalHighSurrogate = 0;
-    yyline = yychar = yycolumn = 0;
+    yyResetPosition();
     zzLexicalState = YYINITIAL;
     if (zzBuffer.length > ZZ_BUFFERSIZE) {
       zzBuffer = new char[ZZ_BUFFERSIZE];
     }
   }
 
+  /**
+   * Resets the input position.
+   */
+  private final void yyResetPosition() {
+      zzAtBOL  = true;
+      zzAtEOF  = false;
+      zzCurrentPos = 0;
+      zzMarkedPos = 0;
+      zzStartRead = 0;
+      zzEndRead = 0;
+      zzFinalHighSurrogate = 0;
+      yyline = 0;
+      yycolumn = 0;
+      yychar = 0L;
+  }
+
+
+  /**
+   * Returns whether the scanner has reached the end of the reader it reads from.
+   *
+   * @return whether the scanner has reached EOF.
+   */
+  public final boolean yyatEOF() {
+    return zzAtEOF;
+  }
+
 
   /**
    * Returns the current lexical state.
+   *
+   * @return the current lexical state.
    */
   public final int yystate() {
     return zzLexicalState;
@@ -211,6 +223,8 @@
 
   /**
    * Returns the text matched by the current regular expression.
+   *
+   * @return the matched text.
    */
   public final String yytext() {
     return new String(zzBuffer, zzStartRead, zzMarkedPos-zzStartRead);
@@ -232,7 +246,9 @@
 
 
   /**
-   * Returns the length of the matched text region.
+   * How many characters were matched.
+   *
+   * @return the length of the matched text region.
    */
   public final int yylength() {
     return zzMarkedPos-zzStartRead;

--- a/testsuite/testcases/src/test/cases/spoon-feed-reader/problematic.skeleton.default
+++ b/testsuite/testcases/src/test/cases/spoon-feed-reader/problematic.skeleton.default
@@ -53,23 +53,8 @@
   /** Marks the last character in the buffer, that has been read from input. */
   private int zzEndRead;
 
-  /** Number of newlines encountered up to the start of the matched text. */
-  private int yyline;
-
-  /** Number of characters up to the start of the matched text. */
-  private int yychar;
-
-  /** Number of characters from the last newline up to the start of the matched text. */
-  private int yycolumn;
-
-  /** Whether the scanner is currently at the beginning of a line. */
-  private boolean zzAtBOL = true;
-
   /** Whether the scanner is at the end of line. */
   private boolean zzAtEOF;
-
-  /** Whether the user-EOF-code has already been executed. */
-  private boolean zzEOFDone;
 
   /**
    * The number of occupied positions in {@link #zzBuffer} beyond {@link #zzEndRead}.
@@ -179,7 +164,9 @@
     zzEndRead = zzStartRead = 0;
     zzCurrentPos = zzMarkedPos = 0;
     zzFinalHighSurrogate = 0;
-    yyline = yychar = yycolumn = 0;
+    yyline = 0;
+    yychar = 0;
+    yycolumn = 0;
     zzLexicalState = YYINITIAL;
     if (zzBuffer.length > ZZ_BUFFERSIZE) {
       zzBuffer = new char[ZZ_BUFFERSIZE];


### PR DESCRIPTION
* suppress "unused" warnings for generated yychar, yyline, etc (when actually unused)
* (includes skeleton sync with tests)
* address more error-prone warnings