### PR TITLE
Make maven build reproducible

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,7 @@
     <maven.compiler.source>${jflex.jdk.version}</maven.compiler.source>
     <maven.compiler.target>${jflex.jdk.version}</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.build.outputTimestamp>1</project.build.outputTimestamp>
   </properties>
 
   <issueManagement>
@@ -271,7 +272,7 @@
         </plugin>
         <plugin>
           <artifactId>maven-release-plugin</artifactId>
-          <version>2.5.3</version>
+          <version>3.0.0-M1</version>
           <configuration>
             <autoVersionSubmodules>true</autoVersionSubmodules>
             <preparationGoals>clean install</preparationGoals>

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,8 @@
     <maven.compiler.source>${jflex.jdk.version}</maven.compiler.source>
     <maven.compiler.target>${jflex.jdk.version}</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <project.build.outputTimestamp>1</project.build.outputTimestamp>
+    <!-- activates reproducible builds, will be replaced by release:prepare -->
+    <project.build.outputTimestamp>2023-01-01T00:00:00Z</project.build.outputTimestamp>
   </properties>
 
   <issueManagement>
@@ -272,7 +273,7 @@
         </plugin>
         <plugin>
           <artifactId>maven-release-plugin</artifactId>
-          <version>3.0.0-M1</version>
+          <version>3.0.0-M7</version>
           <configuration>
             <autoVersionSubmodules>true</autoVersionSubmodules>
             <preparationGoals>clean install</preparationGoals>


### PR DESCRIPTION
- Hardcode an initial value for `<project.build.outputTimestamp>`
- Update maven plugins to version 3.2+

see https://maven.apache.org/guides/mini/guide-reproducible-builds.html


