### PR TITLE
bump guava version

### DIFF
--- a/jflex-maven-plugin/src/main/java/jflex/maven/plugin/jflex/JFlexMojo.java
+++ b/jflex-maven-plugin/src/main/java/jflex/maven/plugin/jflex/JFlexMojo.java
@@ -11,8 +11,8 @@ package jflex.maven.plugin.jflex;
 import static com.google.common.base.Strings.isNullOrEmpty;
 
 import com.google.common.base.Predicate;
-import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
 import com.google.common.io.Files;
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -177,10 +177,10 @@ public class JFlexMojo extends AbstractMojo {
     if (lexDefinition.isDirectory()) {
       // recursively process files contained within
       getLog().debug("Processing lexer files found in " + lexDefinition);
-      FluentIterable<File> files =
-          Files.fileTreeTraverser()
-              .preOrderTraversal(lexDefinition)
-              .filter(new ExtensionPredicate("jflex", "jlex", "lex", "flex"));
+      Iterable<File> files =
+          Iterables.filter(
+              Files.fileTraverser().depthFirstPreOrder(lexDefinition),
+              new ExtensionPredicate("jflex", "jlex", "lex", "flex"));
       for (File lexFile : files) {
         parseLexFile(lexFile);
       }

--- a/pom.xml
+++ b/pom.xml
@@ -122,8 +122,7 @@
       <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
-        <!-- Release 21.0 requires JDK 1.8 or newer. -->
-        <version>20.0</version>
+        <version>26.0-jre</version>
       </dependency>
       <dependency>
         <groupId>com.google.truth</groupId>


### PR DESCRIPTION
I don't think JFlex uses any of the code in [CVE-2018-10237](https://github.com/advisories/GHSA-mvr2-9pj6-7w5j), but it's better to use the same version (26.0-jre) across the whole project anyway.