### PR TITLE
Bump to Bazel 3.5.0

### DIFF
--- a/.ci.bazelrc
+++ b/.ci.bazelrc
@@ -1,5 +1,7 @@
 import %workspace%/.bazelrc
 
+# Default cache timeout is 60 sec
+build --remote_timeout=15
 # This is so we understand failures better
 build --verbose_failures
 test  --test_output=errors

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -8,20 +8,14 @@ container:
   image: l.gcr.io/google/bazel:3.5.0
   memory: 5G
 
-bazel_build__test_task:
+bazel_build_test_task:
   name: Bazel build and test
   bazel_version_script:
-  - bazel --bazelrc=.ci.bazelrc info  --remote_http_cache=http://$CIRRUS_HTTP_CACHE_HOST  release
-  build_script:
-  - bazel --bazelrc=.ci.bazelrc build --remote_http_cache=http://$CIRRUS_HTTP_CACHE_HOST  //jflex
+  - bazel --bazelrc=.ci.bazelrc info  release
   build_all_script:
-  - bazel --bazelrc=.ci.bazelrc build --remote_http_cache=http://$CIRRUS_HTTP_CACHE_HOST  //...
-  test_script:
-  - bazel --bazelrc=.ci.bazelrc test  --remote_http_cache=http://$CIRRUS_HTTP_CACHE_HOST  //jflex/...
-  regression_tests_script:
-  - bazel --bazelrc=.ci.bazelrc test  --remote_http_cache=http://$CIRRUS_HTTP_CACHE_HOST  //javatests/jflex/testcase/...
+  - bazel --bazelrc=.ci.bazelrc build //...
   test_all_script:
-  - bazel --bazelrc=.ci.bazelrc test  --remote_http_cache=http://$CIRRUS_HTTP_CACHE_HOST  //...
+  - bazel --bazelrc=.ci.bazelrc test  //...
   always:
     junit_artifacts:
       path: "bazel-out/*/testlogs/**/test.xml"
@@ -31,7 +25,7 @@ bazel_build__test_task:
 bazel_artifact_task:
   name: Bazel artifact
   build_artifact_script:
-  - bazel --bazelrc=.ci.bazelrc build --remote_http_cache=http://$CIRRUS_HTTP_CACHE_HOST  jflex/jflex_bin_deploy.jar
+  - bazel --bazelrc=.ci.bazelrc build jflex/jflex_bin_deploy.jar
   binary_artifacts:
     path: "bazel-out/*/bin/jflex/jflex_bin_deploy.jar"
     type: application/java-archive
@@ -39,7 +33,7 @@ bazel_artifact_task:
 measure_coverage_task:
   name: Measure code coverage
   measure_coverage_script:
-  - bazel --bazelrc=.ci.bazelrc coverage --combined_report=none --remote_http_cache=http://$CIRRUS_HTTP_CACHE_HOST  //javatests/... //jflex/...
+  - bazel --bazelrc=.ci.bazelrc coverage --combined_report=none //javatests/... //jflex/...
   send_coverage_report_script:
   - scripts/send-code-coverage.sh
   only_if: $CIRRUS_BRANCH == $CIRRUS_DEFAULT_BRANCH || $CIRRUS_BRANCH == 'cirrus'

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -5,7 +5,7 @@ buildtools_cache:
   folder: buildtools
 
 container:
-  image: l.gcr.io/google/bazel:2.1.0
+  image: l.gcr.io/google/bazel:3.5.0
   memory: 5G
 
 bazel_build__test_task:

--- a/java/jflex/util/javac/CompilerException.java
+++ b/java/jflex/util/javac/CompilerException.java
@@ -59,7 +59,7 @@ public class CompilerException extends Exception {
   }
 
   @Override
-  public String toString() {
+  public String getMessage() {
     List<String> diagnosticMessages =
         diagnostics.stream()
             .map(
@@ -68,7 +68,7 @@ public class CompilerException extends Exception {
                         "javac error: %s, line %d in file %s",
                         d.getMessage(Locale.ENGLISH), d.getLineNumber(), d.getSource().getName()))
             .collect(Collectors.toList());
-    return super.toString() + "\n" + Joiner.on('\n').join(diagnosticMessages);
+    return Joiner.on('\n').join(diagnosticMessages);
   }
 
   private static String diagnosticCode(List<Diagnostic<? extends JavaFileObject>> diagnostics) {

--- a/javatests/jflex/testcase/apipirivate/ApiPrivateTest.java
+++ b/javatests/jflex/testcase/apipirivate/ApiPrivateTest.java
@@ -66,7 +66,7 @@ public class ApiPrivateTest {
               srcFiles.stream().map(File::getAbsolutePath).collect(joining(", ")))
           .that(e)
           .hasMessageThat()
-          .contains("compiler.err.report.access");
+          .contains("yylex() has private access in jflex.testcase.apipirivate.PrivateScanner");
     }
   }
 }

--- a/jflex/src/main/java/jflex/core/AbstractLexScan.java
+++ b/jflex/src/main/java/jflex/core/AbstractLexScan.java
@@ -370,8 +370,8 @@ public abstract class AbstractLexScan implements ILexScan {
     return lexLine();
   }
 
-  @SuppressWarnings("unused") // Used by generated LexScan
   /** @deprecated Use {@link #columnCoount} */
+  @SuppressWarnings("unused") // Used by generated LexScan
   @Deprecated
   public boolean isColumnCount() {
     return columnCount;

--- a/jflex/src/main/java/jflex/core/Macros.java
+++ b/jflex/src/main/java/jflex/core/Macros.java
@@ -13,9 +13,11 @@ import static jflex.l10n.ErrorMessages.MACRO_CYCLE;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import jflex.base.Build;
 import jflex.exceptions.MacroException;
 import jflex.l10n.ErrorMessages;
@@ -123,11 +125,11 @@ public final class Macros {
    * @throws MacroException if there is a cycle in the macro usage graph.
    */
   public void expand() throws MacroException {
-    for (String name : macros.keySet()) {
+    Set<String> keys = new HashSet(macros.keySet());
+    for (String name : keys) {
       if (isUsed(name)) {
-        macros.put(name, expandMacro(name, getDefinition(name)));
+        macros.replace(name, expandMacro(name, getDefinition(name)));
       }
-      // this put doesn't get a new key, so only a new value is set for the key "name"
     }
   }
 

--- a/jflex/src/test/java/jflex/state/StateSetQuickcheck.java
+++ b/jflex/src/test/java/jflex/state/StateSetQuickcheck.java
@@ -30,7 +30,7 @@ import org.junit.runner.RunWith;
 public class StateSetQuickcheck {
 
   @Property
-  public void size2nbits(@InRange(minInt = 1, maxInt = 2 ^ 58) int size) {
+  public void size2nbits(@InRange(minInt = 1, maxInt = 56) int size) {
     assertThat(StateSet.size2nbits(StateSet.nbits2size(size))).isEqualTo(size);
   }
 
@@ -175,20 +175,20 @@ public class StateSetQuickcheck {
   }
 
   @Property
-  public void addStateAdds(StateSet set, @InRange(minInt = 0, maxInt = 2 ^ 32) int e) {
+  public void addStateAdds(StateSet set, @InRange(minInt = 0, maxInt = 34) int e) {
     set.addState(e);
     assertThat(set.hasElement(e)).isTrue();
   }
 
   @Property
-  public void addStateDoesNotRemove(StateSet set, @InRange(minInt = 0, maxInt = 2 ^ 32) int e) {
+  public void addStateDoesNotRemove(StateSet set, @InRange(minInt = 0, maxInt = 34) int e) {
     StateSet setPre = new StateSet(set);
     set.addState(e);
     assertThat(set.contains(setPre)).isTrue();
   }
 
   @Property
-  public void addStateAdd(StateSet set, @InRange(minInt = 0, maxInt = 2 ^ 32) int e) {
+  public void addStateAdd(StateSet set, @InRange(minInt = 0, maxInt = 34) int e) {
     StateSet set2 = new StateSet(set);
     set.addState(e);
     set2.add(new StateSet(10, e));
@@ -225,7 +225,7 @@ public class StateSetQuickcheck {
   }
 
   @Property
-  public void containsElements(StateSet s, @InRange(minInt = 0, maxInt = 2 ^ 32) int e) {
+  public void containsElements(StateSet s, @InRange(minInt = 0, maxInt = 34) int e) {
     s.addState(e);
     assertThat(s.containsElements()).isTrue();
   }


### PR DESCRIPTION
Bump from Bazel 2.1.0 to Bazel 3.5.0 (latest docker image)

Also fix
- https://errorprone.info/bugpattern/OverrideThrowableToString in CompilerException
- https://google.github.io/styleguide/javaguide.html#s4.8.5-annotations in AbstractLexScan.java:376
- https://errorprone.info/bugpattern/ModifyCollectionInEnhancedForLoop in Macros.java:128