### PR TITLE
UCD Generator: Normalize Script_Extensions values

### DIFF
--- a/java/jflex/ucd_generator/UcdScanner.java
+++ b/java/jflex/ucd_generator/UcdScanner.java
@@ -79,6 +79,10 @@ public class UcdScanner {
               Files.newReader(file, StandardCharsets.UTF_8), unicodeData);
       scanner.scan();
     }
+    // Clone Script/sc property value aliases => Script_Extensions/scx
+    String scPropName = unicodeData.getCanonicalPropertyName("Script");
+    String scxPropName = unicodeData.getCanonicalPropertyName("Script_Extensions");
+    unicodeData.copyPropertyValueAliases(scPropName, scxPropName);
   }
 
   void scanUnicodeData() throws IOException {

--- a/java/jflex/ucd_generator/model/PropertyValues.java
+++ b/java/jflex/ucd_generator/model/PropertyValues.java
@@ -73,4 +73,10 @@ public class PropertyValues {
     }
     return canonicalPropValueNames.get(canonicalValue);
   }
+
+  public void copyPropertyValueAliases(String sourceProperty, String destProperty) {
+    allPropertyValueAliases.put(destProperty, allPropertyValueAliases.get(sourceProperty));
+    propertyValueAlias2CanonicalValue.put(
+        destProperty, propertyValueAlias2CanonicalValue.get(sourceProperty));
+  }
 }

--- a/java/jflex/ucd_generator/model/UnicodeData.java
+++ b/java/jflex/ucd_generator/model/UnicodeData.java
@@ -62,16 +62,21 @@ public class UnicodeData {
   }
 
   public void addPropertyValueAliases(
-      String propertyName, String normalizedPropertyValue, Set<String> aliases) {
-    propertyValues.addPropertyValueAliases(propertyName, normalizedPropertyValue, aliases);
-  }
-
-  public Collection<String> getPropertyAliases(String propName) {
-    return propertyNameNormalizer.getPropertyAliases(propName);
+      String normalizedPropertyName, String normalizedPropertyValue, Set<String> aliases) {
+    propertyValues.addPropertyValueAliases(
+        normalizedPropertyName, normalizedPropertyValue, aliases);
   }
 
   public Collection<String> getPropertyValueAliases(String propName, String propValue) {
     return propertyValues.getPropertyValueAliases(propName, propValue);
+  }
+
+  public void copyPropertyValueAliases(String sourceProperty, String destProperty) {
+    propertyValues.copyPropertyValueAliases(sourceProperty, destProperty);
+  }
+
+  public Collection<String> getPropertyAliases(String propName) {
+    return propertyNameNormalizer.getPropertyAliases(propName);
   }
 
   public void addBinaryPropertyInterval(String propertyName, int start, int end) {

--- a/java/jflex/ucd_generator/scanner/AbstractPropertyValueAliasesScanner.java
+++ b/java/jflex/ucd_generator/scanner/AbstractPropertyValueAliasesScanner.java
@@ -10,8 +10,6 @@ public abstract class AbstractPropertyValueAliasesScanner {
 
   private final UnicodeData unicodeData;
 
-  final String scxPropName;
-
   protected final Set<String> aliases = new HashSet<>();
 
   protected String propertyAlias;
@@ -19,7 +17,6 @@ public abstract class AbstractPropertyValueAliasesScanner {
 
   public AbstractPropertyValueAliasesScanner(UnicodeData unicodeData) {
     this.unicodeData = unicodeData;
-    scxPropName = unicodeData.getCanonicalPropertyName("Script_Extensions");
   }
 
   /** Populates the property values and property value aliases for a property. */
@@ -33,10 +30,6 @@ public abstract class AbstractPropertyValueAliasesScanner {
       String canonicalPropertyName, String normalizedPropertyValue) {
     aliases.add(normalizedPropertyValue);
     unicodeData.addPropertyValueAliases(canonicalPropertyName, normalizedPropertyValue, aliases);
-    if ("script".equals(canonicalPropertyName)) {
-      // Clone Script/sc property value aliases => Script_Extensions/scx
-      unicodeData.addPropertyValueAliases(scxPropName, normalizedPropertyValue, aliases);
-    }
     aliases.clear();
   }
 }

--- a/java/jflex/ucd_generator/scanner/AbstractPropertyValueAliasesScanner.java
+++ b/java/jflex/ucd_generator/scanner/AbstractPropertyValueAliasesScanner.java
@@ -35,7 +35,7 @@ public abstract class AbstractPropertyValueAliasesScanner {
     unicodeData.addPropertyValueAliases(canonicalPropertyName, normalizedPropertyValue, aliases);
     if ("script".equals(canonicalPropertyName)) {
       // Clone Script/sc property value aliases => Script_Extensions/scx
-      unicodeData.addPropertyValueAliases(scxPropName, propertyValue, aliases);
+      unicodeData.addPropertyValueAliases(scxPropName, normalizedPropertyValue, aliases);
     }
     aliases.clear();
   }

--- a/java/jflex/ucd_generator/scanner/ScriptExtensionsScanner.flex
+++ b/java/jflex/ucd_generator/scanner/ScriptExtensionsScanner.flex
@@ -70,8 +70,7 @@ ItemSeparator = {Spaces} ";" {Spaces}
 <PROPERTY_VALUE> { /* 060C          ; Arab Syrc Thaa # Po       ARABIC COMMA */
   {Spaces} [^ \t\r\n#;]+ { String script = yytext().trim();
                            addScript(script);
-
-                           }
+                         }
 
   {Spaces} ("#" .*)? {NL} { yybegin(YYINITIAL); }
 }

--- a/javatests/jflex/ucd_generator/UcdGeneratorIntegrationTest.java
+++ b/javatests/jflex/ucd_generator/UcdGeneratorIntegrationTest.java
@@ -6,7 +6,6 @@ import com.google.common.io.Files;
 import java.io.File;
 import java.nio.charset.StandardCharsets;
 import jflex.testing.diff.DiffOutputStream;
-import org.junit.Ignore;
 import org.junit.Test;
 
 /** Integration test for {@link UcdGenerator} */
@@ -27,9 +26,6 @@ public class UcdGeneratorIntegrationTest {
   }
 
   @Test
-  @Ignore
-  //  Content differs on line 476:
-  // : expected:<...  "scriptextensions=[a]rabic",> but was:<...  "scriptextensions=[A]rabic",>
   public void emitUnicodeVersionXY_6_3() throws Exception {
     File outputDir = new File("/tmp");
     UcdGenerator.emitUnicodeVersionXY(TestedVersions.UCD_VERSION_6_3, outputDir);


### PR DESCRIPTION
With this change, the Unicode_6_3 is identical to the generation of the unicode-maven-plugin.
