### PR TITLE
Add missing "scriptextensions" self-alias

### DIFF
--- a/java/jflex/ucd_generator/UcdScanner.java
+++ b/java/jflex/ucd_generator/UcdScanner.java
@@ -41,6 +41,7 @@ public class UcdScanner {
     try {
       scanPropertyAliases();
       scanPropertyValueAliases();
+      cloneScriptsToScriptExtensions();
       scanUnicodeData();
       scanPropList();
       scanDerivedCoreProperties();
@@ -83,6 +84,9 @@ public class UcdScanner {
               Files.newReader(file, StandardCharsets.UTF_8), unicodeData);
       scanner.scan();
     }
+  }
+
+  private void cloneScriptsToScriptExtensions() {
     // Clone Script/sc property value aliases => Script_Extensions/scx
     String scPropName = unicodeData.getCanonicalPropertyName("Script");
     String scxPropName = unicodeData.getCanonicalPropertyName("Script_Extensions");

--- a/java/jflex/ucd_generator/model/UnicodeData.java
+++ b/java/jflex/ucd_generator/model/UnicodeData.java
@@ -73,6 +73,7 @@ public class UnicodeData {
 
   public void copyPropertyValueAliases(String sourceProperty, String destProperty) {
     propertyValues.copyPropertyValueAliases(sourceProperty, destProperty);
+    propertyNameNormalizer.putPropertyAlias(destProperty, destProperty);
   }
 
   public Collection<String> getPropertyAliases(String propName) {

--- a/java/jflex/ucd_generator/util/PropertyNameNormalizer.java
+++ b/java/jflex/ucd_generator/util/PropertyNameNormalizer.java
@@ -18,10 +18,12 @@ public class PropertyNameNormalizer {
   // "cache"
   private static final Map<String, String> normalized = new HashMap<>();
 
-  /** Normalized General_Category property name */
+  /** Normalized General_Category property name. */
   public static final String NORMALIZED_GENERAL_CATEGORY = normalize("General_Category");
-  /** Normalized Script property name */
+  /** Normalized Script property name. */
   public static final String NORMALIZED_SCRIPT = normalize("Script");
+  /** Normalized Scirpt_Extensions property name. */
+  public static final String NORMALIZED_SCRIPT_EXTENSIONS = normalize("Script_Extensions");
 
   public static final ImmutableSet<String> DEFAULT_CATEGORIES =
       ImmutableSet.of(NORMALIZED_GENERAL_CATEGORY, NORMALIZED_SCRIPT);

--- a/javatests/jflex/ucd_generator/UcdGeneratorIntegrationTest.java
+++ b/javatests/jflex/ucd_generator/UcdGeneratorIntegrationTest.java
@@ -93,13 +93,6 @@ public class UcdGeneratorIntegrationTest {
   }
 
   @Test
-  @Ignore // TODO(regisd) Fix test failure
-  // propertyValueAliases  missing the following entries:
-  // {
-  //   scriptextensions=arab=scriptextensions=arabic,
-  //   scriptextensions=armi=scriptextensions=imperialaramaic,
-  //   etc.
-  // }
   public void emitUnicodeVersionXY_6_0() throws Exception {
     File f = generateUnicodeProperties(TestedVersions.UCD_VERSION_6_0);
 

--- a/javatests/jflex/ucd_generator/UcdGeneratorIntegrationTest.java
+++ b/javatests/jflex/ucd_generator/UcdGeneratorIntegrationTest.java
@@ -14,7 +14,6 @@ import java.util.List;
 import jflex.testing.diff.DiffOutputStream;
 import jflex.testing.javaast.BasicJavaInterpreter;
 import jflex.ucd_generator.ucd.UcdVersion;
-import org.junit.Ignore;
 import org.junit.Test;
 
 /**


### PR DESCRIPTION
In Unicode 6, Script_Extensions doens't have the alias "scx". However, in the implementation all properties are supposed to be self-aliased.

When we copy the Scrips to the Script_Extensions, also call `propertyNameNormalizer.putPropertyAlias("scriptextensions", "scriptextensions");`

Fixes a bug discovered thanks to #821 