### PR TITLE
DerivedAgeScanner shouldn't create intervals above maximumCodepoint

### DIFF
--- a/java/de/jflex/ucd_generator/scanner/UcdScanner.java
+++ b/java/de/jflex/ucd_generator/scanner/UcdScanner.java
@@ -204,7 +204,11 @@ public class UcdScanner {
     if (file != null) {
       assertFileExists(file);
       DerivedAgeScanner scanner =
-          new DerivedAgeScanner(Files.newReader(file, StandardCharsets.UTF_8), unicodeData, "Age");
+          new DerivedAgeScanner(
+              Files.newReader(file, StandardCharsets.UTF_8),
+              unicodeData,
+              "Age",
+              unicodeData.maximumCodePoint());
       scanner.scan();
     }
   }


### PR DESCRIPTION
Follow-up of #831
Fixes workaround  #833