### PR TITLE
addEnumPropertyInterval doesn't need hack for Unicode 2.1 anymore

### DIFF
--- a/java/de/jflex/ucd_generator/ucd/UnicodeData.java
+++ b/java/de/jflex/ucd_generator/ucd/UnicodeData.java
@@ -88,15 +88,6 @@ public class UnicodeData {
   }
 
   public void addEnumPropertyInterval(String propName, String propValue, int start, int end) {
-    if (start > 0xffff
-        && Version.MAJOR_MINOR_COMPARATOR.compare(version, Versions.VERSION_3_0) < 0) {
-      // TODO(regisd) https://github.com/jflex-de/jflex/issues/833
-      // Work around Unicode 2.1 having for property value Age=2.0
-      // intervals "\ud83f\udffe\ud83f\udfff"
-      //           "\ud87f\udffe\ud87f\udfff"
-      //           etc.
-      return;
-    }
     propName = propertyNameNormalizer.getCanonicalPropertyName(propName);
     propertyValueIntervals.addEnumPropertyInterval(propName, propValue, start, end);
   }


### PR DESCRIPTION
Fixed in #837
Remove workaround for #833
Follow-up of #831