### PR TITLE
Simplify velocity invocation with new render(..., File) method.

### DIFF
--- a/java/de/jflex/migration/BUILD.bazel
+++ b/java/de/jflex/migration/BUILD.bazel
@@ -3,7 +3,7 @@ load("@jflex_rules//jflex:jflex.bzl", "jflex")
 java_binary(
     name = "migrator",
     srcs = [],
-    main_class = "jflex.migration.Migrator",
+    main_class = "de.jflex.migration.Migrator",
     runtime_deps = [":migration"],
 )
 

--- a/java/de/jflex/migration/README.md
+++ b/java/de/jflex/migration/README.md
@@ -17,7 +17,7 @@ git co -b bzl-migrate-vaseless-jflex
 
 ### Run the automatic migration
 ```
-bazel run java/jflex/migration:migrator -- ~/Projects/jflex/testsuite/testcases/src/test/cases/caseless-jflex
+bazel run java/de/jflex/migration:migrator -- ~/Projects/jflex/testsuite/testcases/src/test/cases/caseless-jflex
 cp -r /tmp/caseless_jflex ~/Projects/jflex/javatests/de/jflex/testcase
 ```
 

--- a/java/de/jflex/ucd_generator/emitter/unicode_properties/UnicodePropertiesEmitter.java
+++ b/java/de/jflex/ucd_generator/emitter/unicode_properties/UnicodePropertiesEmitter.java
@@ -30,12 +30,8 @@ import de.jflex.ucd_generator.emitter.common.UcdEmitter;
 import de.jflex.ucd_generator.ucd.UcdVersions;
 import de.jflex.util.javac.JavaPackageUtils;
 import de.jflex.velocity.Velocity;
-import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.io.OutputStreamWriter;
-import java.io.Writer;
-import java.nio.charset.StandardCharsets;
 import org.apache.velocity.runtime.parser.ParseException;
 
 /** UnicodePropertiesEmitter for {@code UnicodeProperties.java}. */
@@ -54,14 +50,11 @@ public class UnicodePropertiesEmitter extends UcdEmitter {
 
   public void emitUnicodeProperties(OutputStream output) throws IOException, ParseException {
     UnicodePropertiesVars unicodePropertiesVars = createUnicodePropertiesVars();
-    try (Writer writer =
-        new BufferedWriter(new OutputStreamWriter(output, StandardCharsets.UTF_8))) {
-      Velocity.render(
-          readResource(UNICODE_PROPERTIES_TEMPLATE),
-          "UnicodeProperties",
-          unicodePropertiesVars,
-          writer);
-    }
+    Velocity.render(
+        readResource(UNICODE_PROPERTIES_TEMPLATE),
+        "UnicodeProperties",
+        unicodePropertiesVars,
+        output);
   }
 
   private UnicodePropertiesVars createUnicodePropertiesVars() {

--- a/java/de/jflex/ucd_generator/emitter/unicode_version/UnicodeVersionEmitter.java
+++ b/java/de/jflex/ucd_generator/emitter/unicode_version/UnicodeVersionEmitter.java
@@ -40,12 +40,8 @@ import de.jflex.ucd_generator.ucd.UnicodeData;
 import de.jflex.ucd_generator.util.JavaStrings;
 import de.jflex.util.javac.JavaPackageUtils;
 import de.jflex.velocity.Velocity;
-import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.io.OutputStreamWriter;
-import java.io.Writer;
-import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.Map;
@@ -70,11 +66,8 @@ public class UnicodeVersionEmitter extends UcdEmitter {
 
   public void emitUnicodeVersion(OutputStream output) throws IOException, ParseException {
     UnicodeVersionVars unicodeVersionVars = createUnicodeVersionVars();
-    try (Writer writer =
-        new BufferedWriter(new OutputStreamWriter(output, StandardCharsets.UTF_8))) {
-      Velocity.render(
-          readResource(UNICODE_VERSION_TEMPLATE), "Unicode_x_y", unicodeVersionVars, writer);
-    }
+    Velocity.render(
+        readResource(UNICODE_VERSION_TEMPLATE), "Unicode_x_y", unicodeVersionVars, output);
   }
 
   private UnicodeVersionVars createUnicodeVersionVars() {

--- a/java/de/jflex/velocity/Velocity.java
+++ b/java/de/jflex/velocity/Velocity.java
@@ -25,9 +25,15 @@
  */
 package de.jflex.velocity;
 
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
 import java.io.Reader;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 import org.apache.velocity.VelocityContext;
 import org.apache.velocity.runtime.RuntimeConstants;
 import org.apache.velocity.runtime.RuntimeInstance;
@@ -49,6 +55,23 @@ public class Velocity {
     VelocityContext velocityContext = templateVars.toVelocityContext();
     SimpleNode tpl = Velocity.parsedTemplateForResource(templateReader, templateName);
     VELOCITY_INSTANCE.render(velocityContext, writer, templateName, tpl);
+  }
+
+  public static void render(
+      Reader templateReader, String templateName, TemplateVars templateVars, OutputStream output)
+      throws IOException, ParseException {
+    try (Writer writer =
+        new BufferedWriter(new OutputStreamWriter(output, StandardCharsets.UTF_8))) {
+      render(templateReader, templateName, templateVars, writer);
+    }
+  }
+
+  public static void render(
+      Reader templateReader, String templateName, TemplateVars templateVars, File output)
+      throws IOException, ParseException {
+    try (OutputStream out = new FileOutputStream(output)) {
+      render(templateReader, templateName, templateVars, out);
+    }
   }
 
   private static SimpleNode parsedTemplateForResource(Reader template, String templateName) {


### PR DESCRIPTION
Add a method that takes a file, which saves the caller to create a stream from file.

Tested:
```
bazel run java/de/jflex/migration:migrator -- ~/Projects/jflex/testsuite/testcases/src/test/cases/syntaxnull
```

with 
which needed few adjsutments following #827