### PR TITLE
Improve error message in JFlexTestRunner

### DIFF
--- a/java/de/jflex/testing/diff/BUILD.bazel
+++ b/java/de/jflex/testing/diff/BUILD.bazel
@@ -5,6 +5,7 @@ java_library(
     testonly = True,
     srcs = ["DiffOutputStream.java"],
     deps = [
+        "//third_party/com/google/guava",
         "//third_party/com/google/truth",
         "//third_party/junit",
     ],

--- a/java/de/jflex/testing/testsuite/JFlexTestRunner.java
+++ b/java/de/jflex/testing/testsuite/JFlexTestRunner.java
@@ -163,6 +163,10 @@ public class JFlexTestRunner extends BlockJUnit4ClassRunner {
       try {
         DiffOutputStream diffSysOut =
             new DiffOutputStream(Files.newReader(sysoutFile, StandardCharsets.UTF_8));
+        diffSysOut.setComparisonFailureHandler(
+            failure -> {
+              throw new Error("System.out differs: " + spec.sysout(), failure);
+            });
         Out.setOutputStream(diffSysOut);
         return Optional.of(diffSysOut);
       } catch (FileNotFoundException e) {
@@ -179,6 +183,10 @@ public class JFlexTestRunner extends BlockJUnit4ClassRunner {
       try {
         DiffOutputStream diffSysErr =
             new DiffOutputStream(Files.newReader(syserrFile, StandardCharsets.UTF_8));
+        diffSysErr.setComparisonFailureHandler(
+            failure -> {
+              throw new Error("System.err differs: " + spec.syserr(), failure);
+            });
         System.setErr(new PrintStream(diffSysErr));
         return Optional.of(diffSysErr);
       } catch (FileNotFoundException e) {


### PR DESCRIPTION
By default, the DiffOutputStream throws a ComparisonFailure when content differs.

Allow to set a custom handler, so that a test can JFlexTestRunner print in System.err
This allows a more descriptive Error (instead of a generic ComparisonFailure)
