### PR TITLE
Make quiet logging actually quiet

### DIFF
--- a/java/de/jflex/testing/testsuite/JFlexTestRunner.java
+++ b/java/de/jflex/testing/testsuite/JFlexTestRunner.java
@@ -40,6 +40,7 @@ import java.io.FileNotFoundException;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
+import java.util.logging.Level;
 import jflex.core.OptionUtils;
 import jflex.generator.LexGenerator;
 import jflex.logging.Out;
@@ -203,7 +204,7 @@ public class JFlexTestRunner extends BlockJUnit4ClassRunner {
     }
     Options.jlex = spec.jlexCompat();
     Options.dump = spec.dump();
-    Options.verbose = !spec.quiet();
+    Options.logLevel = spec.quiet() ? Level.SEVERE : Level.WARNING;
     Options.unused_warning = spec.warnUnused();
     LexGenerator lexGenerator = new LexGenerator(new File(spec.lex()));
     String lexerJavaFileName = checkNotNull(lexGenerator.generate());

--- a/jflex-maven-plugin/src/main/java/jflex/maven/plugin/jflex/JFlexMojo.java
+++ b/jflex-maven-plugin/src/main/java/jflex/maven/plugin/jflex/JFlexMojo.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.logging.Level;
 import jflex.core.OptionUtils;
 import jflex.generator.LexGenerator;
 import jflex.option.Options;
@@ -214,7 +215,9 @@ public class JFlexMojo extends AbstractMojo {
     OptionUtils.setDir(generatedFile.getParentFile());
     Options.setRootDirectory(project.getBasedir());
     Options.dump = dump;
-    Options.verbose = verbose;
+    if (verbose) {
+      Options.logLevel = Level.INFO;
+    }
     Options.unused_warning = unusedWarning;
     Options.dot = dot;
     Options.legacy_dot = legacyDot;

--- a/jflex/src/main/java/jflex/Main.java
+++ b/jflex/src/main/java/jflex/Main.java
@@ -19,6 +19,7 @@ import java.util.SortedMap;
 import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.TreeSet;
+import java.util.logging.Level;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import jflex.base.Build;
@@ -96,7 +97,7 @@ public class Main {
       if (Objects.equals(argv[i], "-v")
           || Objects.equals(argv[i], "--verbose")
           || Objects.equals(argv[i], "-verbose")) { // $NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-        Options.verbose = true;
+        Options.logLevel = Level.INFO;
         Options.progress = true;
         Options.unused_warning = true;
         continue;
@@ -105,7 +106,7 @@ public class Main {
       if (Objects.equals(argv[i], "-q")
           || Objects.equals(argv[i], "--quiet")
           || Objects.equals(argv[i], "-quiet")) { // $NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-        Options.verbose = false;
+        Options.logLevel = Level.SEVERE;
         Options.progress = false;
         Options.unused_warning = false;
         Options.warning = false;

--- a/jflex/src/main/java/jflex/Main.java
+++ b/jflex/src/main/java/jflex/Main.java
@@ -108,6 +108,7 @@ public class Main {
         Options.verbose = false;
         Options.progress = false;
         Options.unused_warning = false;
+        Options.warning = false;
         continue;
       }
 

--- a/jflex/src/main/java/jflex/Main.java
+++ b/jflex/src/main/java/jflex/Main.java
@@ -109,7 +109,6 @@ public class Main {
         Options.logLevel = Level.SEVERE;
         Options.progress = false;
         Options.unused_warning = false;
-        Options.warning = false;
         continue;
       }
 

--- a/jflex/src/main/java/jflex/anttask/JFlexTask.java
+++ b/jflex/src/main/java/jflex/anttask/JFlexTask.java
@@ -240,7 +240,7 @@ public class JFlexTask extends Task {
    * @param verbose a boolean.
    */
   public final void setVerbose(boolean verbose) {
-    Options.logLevel = verbose ? Level.FINE : Level.WARNING;
+    Options.logLevel = verbose ? Level.INFO : Level.WARNING;
     Options.unused_warning = verbose;
   }
 

--- a/jflex/src/main/java/jflex/anttask/JFlexTask.java
+++ b/jflex/src/main/java/jflex/anttask/JFlexTask.java
@@ -16,11 +16,13 @@ import java.io.LineNumberReader;
 import java.io.Reader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.util.logging.Level;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import jflex.core.OptionUtils;
 import jflex.exceptions.GeneratorException;
 import jflex.generator.LexGenerator;
+import jflex.logging.Out;
 import jflex.option.Options;
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Task;
@@ -76,7 +78,9 @@ public class JFlexTask extends Task {
 
         if (inputFile.lastModified() > destFile.lastModified()) {
           new LexGenerator(inputFile).generate();
-          if (!Options.verbose) System.out.println("Generated: " + destFile.getName());
+          if (Out.isLogLevel(Level.INFO)) {
+            System.out.println("Generated: " + destFile.getName());
+          }
         }
       } catch (IOException e1) {
         throw new BuildException(e1);
@@ -236,7 +240,7 @@ public class JFlexTask extends Task {
    * @param verbose a boolean.
    */
   public final void setVerbose(boolean verbose) {
-    Options.verbose = verbose;
+    Options.logLevel = verbose ? Level.FINE : Level.WARNING;
     Options.unused_warning = verbose;
   }
 

--- a/jflex/src/main/java/jflex/core/OptionUtils.java
+++ b/jflex/src/main/java/jflex/core/OptionUtils.java
@@ -30,7 +30,7 @@ public class OptionUtils {
     Options.jlex = false;
     Options.no_minimize = false;
     Options.no_backup = false;
-    Options.logLevel = Level.WARNING;
+    Options.logLevel = Options.DEFAULT_LOG_LEVEL;
     Options.progress = true;
     Options.unused_warning = true;
     Options.time = false;

--- a/jflex/src/main/java/jflex/core/OptionUtils.java
+++ b/jflex/src/main/java/jflex/core/OptionUtils.java
@@ -2,6 +2,7 @@ package jflex.core;
 
 import java.io.File;
 import java.nio.charset.Charset;
+import java.util.logging.Level;
 import jflex.exceptions.GeneratorException;
 import jflex.l10n.ErrorMessages;
 import jflex.logging.Out;
@@ -29,7 +30,7 @@ public class OptionUtils {
     Options.jlex = false;
     Options.no_minimize = false;
     Options.no_backup = false;
-    Options.verbose = true;
+    Options.logLevel = Level.WARNING;
     Options.progress = true;
     Options.unused_warning = true;
     Options.time = false;

--- a/jflex/src/main/java/jflex/core/OptionUtils.java
+++ b/jflex/src/main/java/jflex/core/OptionUtils.java
@@ -2,7 +2,6 @@ package jflex.core;
 
 import java.io.File;
 import java.nio.charset.Charset;
-import java.util.logging.Level;
 import jflex.exceptions.GeneratorException;
 import jflex.l10n.ErrorMessages;
 import jflex.logging.Out;

--- a/jflex/src/main/java/jflex/dfa/DfaFactory.java
+++ b/jflex/src/main/java/jflex/dfa/DfaFactory.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.logging.Level;
 import jflex.core.NFA;
 import jflex.logging.Out;
 import jflex.option.Options;

--- a/jflex/src/main/java/jflex/dfa/DfaFactory.java
+++ b/jflex/src/main/java/jflex/dfa/DfaFactory.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Level;
 import jflex.core.NFA;
 import jflex.logging.Out;
 import jflex.option.Options;
@@ -122,7 +123,7 @@ public class DfaFactory {
       currentDFAState++;
     }
 
-    if (Options.verbose) Out.println("");
+    if (Out.isLogLevel(Level.INFO)) Out.println("");
     return dfa;
   }
 

--- a/jflex/src/main/java/jflex/dfa/DfaFactory.java
+++ b/jflex/src/main/java/jflex/dfa/DfaFactory.java
@@ -123,7 +123,7 @@ public class DfaFactory {
       currentDFAState++;
     }
 
-    if (Out.isLogLevel(Level.INFO)) Out.println("");
+    Out.println("");
     return dfa;
   }
 

--- a/jflex/src/main/java/jflex/gui/OptionsDialog.java
+++ b/jflex/src/main/java/jflex/gui/OptionsDialog.java
@@ -24,8 +24,10 @@ import java.awt.event.ItemListener;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.io.File;
+import java.util.logging.Level;
 import jflex.core.OptionUtils;
 import jflex.exceptions.GeneratorException;
+import jflex.logging.Out;
 import jflex.option.Options;
 import jflex.skeleton.Skeleton;
 
@@ -130,7 +132,7 @@ public class OptionsDialog extends Dialog {
         new ItemListener() {
           @Override
           public void itemStateChanged(ItemEvent e) {
-            Options.verbose = verbose.getState();
+            Options.logLevel = verbose.getState() ? Level.INFO : Level.WARNING;
           }
         });
 
@@ -241,7 +243,7 @@ public class OptionsDialog extends Dialog {
     legacy_dot.setState(Options.legacy_dot);
 
     dump.setState(Options.dump);
-    verbose.setState(Options.verbose);
+    verbose.setState(Out.isLogLevel(Level.INFO));
     time.setState(Options.time);
 
     no_minimize.setState(Options.no_minimize);

--- a/jflex/src/main/java/jflex/logging/Out.java
+++ b/jflex/src/main/java/jflex/logging/Out.java
@@ -15,6 +15,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.Files;
+import java.util.logging.Level;
 import jflex.base.Build;
 import jflex.exceptions.GeneratorException;
 import jflex.l10n.ErrorMessages;
@@ -400,5 +401,10 @@ public final class Out {
     reader.close();
 
     return msg;
+  }
+
+  /** Returns whether the log level is at least the given level. */
+  public static boolean isLogLevel(Level requiredLevel) {
+    return Options.logLevel.intValue() >= requiredLevel.intValue();
   }
 }

--- a/jflex/src/main/java/jflex/logging/Out.java
+++ b/jflex/src/main/java/jflex/logging/Out.java
@@ -207,7 +207,9 @@ public final class Out {
    */
   public static void warning(String message) {
     warnings++;
-
+    if(!Options.warning) {
+      return;
+    }
     err(NL + "Warning : " + message);
   }
 
@@ -230,10 +232,13 @@ public final class Out {
    */
   public static void warning(ErrorMessages.ErrorMessage message, int line) {
     warnings++;
-
+    if(!Options.warning) {
+      return;
+    }
     String msg = NL + "Warning";
-    if (line > 0) msg = msg + " in line " + (line + 1);
-
+    if (line > 0) {
+      msg = msg + " in line " + (line + 1);
+    }
     err(msg + ": " + ErrorMessages.get(message));
   }
 
@@ -246,7 +251,10 @@ public final class Out {
    * @param column the column of the position
    */
   public static void warning(File file, ErrorMessages.ErrorMessage message, int line, int column) {
-
+    warnings++;
+    if(!Options.warning) {
+      return;
+    }
     String msg = NL + "Warning";
     if (file != null) msg += " in file \"" + file + "\"";
     if (line >= 0) msg = msg + " (line " + (line + 1) + ")";
@@ -256,8 +264,6 @@ public final class Out {
     } catch (ArrayIndexOutOfBoundsException e) {
       err(msg);
     }
-
-    warnings++;
 
     if (line >= 0) {
       if (column >= 0) showPosition(file, line, column);

--- a/jflex/src/main/java/jflex/logging/Out.java
+++ b/jflex/src/main/java/jflex/logging/Out.java
@@ -101,7 +101,7 @@ public final class Out {
    * @param message the message to be printed
    */
   public static void println(String message) {
-    if (Options.verbose) {
+    if (isLogLevel(Level.INFO)) {
       out.println(message);
     }
   }
@@ -113,7 +113,7 @@ public final class Out {
    * @param data data to be inserted into the message
    */
   public static void println(ErrorMessages.ErrorMessage message, String data) {
-    if (Options.verbose) {
+    if (isLogLevel(Level.INFO)) {
       out.println(ErrorMessages.get(message, data));
     }
   }
@@ -125,7 +125,7 @@ public final class Out {
    * @param data data to be inserted into the message
    */
   public static void println(ErrorMessages.ErrorMessage message, int data) {
-    if (Options.verbose) {
+    if (isLogLevel(Level.INFO)) {
       out.println(ErrorMessages.get(message, data));
     }
   }
@@ -136,7 +136,7 @@ public final class Out {
    * @param message the message to be printed
    */
   public static void print(String message) {
-    if (Options.verbose) {
+    if (isLogLevel(Level.INFO)) {
       out.print(message);
     }
   }

--- a/jflex/src/main/java/jflex/logging/Out.java
+++ b/jflex/src/main/java/jflex/logging/Out.java
@@ -208,7 +208,7 @@ public final class Out {
    */
   public static void warning(String message) {
     warnings++;
-    if(!isLogLevel(Level.WARNING)) {
+    if (!isLogLevel(Level.WARNING)) {
       return;
     }
     err(NL + "Warning : " + message);
@@ -233,7 +233,7 @@ public final class Out {
    */
   public static void warning(ErrorMessages.ErrorMessage message, int line) {
     warnings++;
-    if(!isLogLevel(Level.WARNING)) {
+    if (!isLogLevel(Level.WARNING)) {
       return;
     }
     String msg = NL + "Warning";
@@ -253,7 +253,7 @@ public final class Out {
    */
   public static void warning(File file, ErrorMessages.ErrorMessage message, int line, int column) {
     warnings++;
-    if(!isLogLevel(Level.WARNING)) {
+    if (!isLogLevel(Level.WARNING)) {
       return;
     }
     String msg = NL + "Warning";

--- a/jflex/src/main/java/jflex/logging/Out.java
+++ b/jflex/src/main/java/jflex/logging/Out.java
@@ -208,7 +208,7 @@ public final class Out {
    */
   public static void warning(String message) {
     warnings++;
-    if(!Options.warning) {
+    if(!isLogLevel(Level.WARNING)) {
       return;
     }
     err(NL + "Warning : " + message);
@@ -233,7 +233,7 @@ public final class Out {
    */
   public static void warning(ErrorMessages.ErrorMessage message, int line) {
     warnings++;
-    if(!Options.warning) {
+    if(!isLogLevel(Level.WARNING)) {
       return;
     }
     String msg = NL + "Warning";
@@ -253,7 +253,7 @@ public final class Out {
    */
   public static void warning(File file, ErrorMessages.ErrorMessage message, int line, int column) {
     warnings++;
-    if(!Options.warning) {
+    if(!isLogLevel(Level.WARNING)) {
       return;
     }
     String msg = NL + "Warning";

--- a/jflex/src/main/java/jflex/logging/README.md
+++ b/jflex/src/main/java/jflex/logging/README.md
@@ -1,0 +1,9 @@
+# Logger
+
+The logger in JFlex is named `Out`.
+
+There are 4 log levels
+* `--progress` To show dots for progress
+* `--verbose` for all informatino
+* warning
+* error

--- a/jflex/src/main/java/jflex/logging/README.md
+++ b/jflex/src/main/java/jflex/logging/README.md
@@ -2,8 +2,7 @@
 
 The logger in JFlex is named `Out`.
 
-There are 4 log levels
-* Level.FINE Enabled with `--verbose` 
-* Level.INFO *default*
-* Level.WARNING Enabled with `--quiet`
-* Level.ERROR
+There are 3 log levels:
+* Level.INFO Enabled with `--verbose` 
+* Level.WARNING *default*
+* Level.ERROR Enabled with `--quiet`

--- a/jflex/src/main/java/jflex/logging/README.md
+++ b/jflex/src/main/java/jflex/logging/README.md
@@ -3,7 +3,7 @@
 The logger in JFlex is named `Out`.
 
 There are 4 log levels
-* `--progress` To show dots for progress
-* `--verbose` for all information.
-* warning. Can be disabled with `--no_warn`
-* error
+* Level.FINE Enabled with `--verbose` 
+* Level.INFO *default*
+* Level.WARNING Enabled with `--quiet`
+* Level.ERROR

--- a/jflex/src/main/java/jflex/logging/README.md
+++ b/jflex/src/main/java/jflex/logging/README.md
@@ -4,6 +4,6 @@ The logger in JFlex is named `Out`.
 
 There are 4 log levels
 * `--progress` To show dots for progress
-* `--verbose` for all informatino
-* warning
+* `--verbose` for all information.
+* warning. Can be disabled with `--no_warn`
 * error

--- a/jflex/src/main/java/jflex/option/Options.java
+++ b/jflex/src/main/java/jflex/option/Options.java
@@ -40,9 +40,8 @@ public class Options {
   public static boolean no_minimize;
   /** don't write backup files if this is true */
   public static boolean no_backup;
+  /** The level of logging. JFlex uses {@link #DEFAULT_LOG_LEVEL} by default. */
   public static Level logLevel = DEFAULT_LOG_LEVEL;
-  /** Whether to show warnings. */
-  public static boolean warning = true;
   /** Whether to warn about unused macros. */
   public static boolean unused_warning;
   /** If true, progress dots will be printed */

--- a/jflex/src/main/java/jflex/option/Options.java
+++ b/jflex/src/main/java/jflex/option/Options.java
@@ -39,6 +39,8 @@ public class Options {
   public static boolean no_backup;
   /** If false, only error/warning output will be generated */
   public static boolean verbose = true;
+  /** Whether to show warnings. */
+  public static boolean warning = true;
   /** Whether to warn about unused macros. */
   public static boolean unused_warning;
   /** If true, progress dots will be printed */

--- a/jflex/src/main/java/jflex/option/Options.java
+++ b/jflex/src/main/java/jflex/option/Options.java
@@ -24,6 +24,8 @@ import java.util.logging.Level;
  */
 public class Options {
 
+  public static final Level DEFAULT_LOG_LEVEL = Level.WARNING;
+
   /** output directory */
   public static File directory;
   /**
@@ -38,7 +40,7 @@ public class Options {
   public static boolean no_minimize;
   /** don't write backup files if this is true */
   public static boolean no_backup;
-  public static Level logLevel;
+  public static Level logLevel = DEFAULT_LOG_LEVEL;
   /** Whether to show warnings. */
   public static boolean warning = true;
   /** Whether to warn about unused macros. */

--- a/jflex/src/main/java/jflex/option/Options.java
+++ b/jflex/src/main/java/jflex/option/Options.java
@@ -11,6 +11,7 @@ package jflex.option;
 
 import java.io.File;
 import java.nio.charset.Charset;
+import java.util.logging.Level;
 
 /**
  * Collects all global JFlex options.
@@ -37,6 +38,7 @@ public class Options {
   public static boolean no_minimize;
   /** don't write backup files if this is true */
   public static boolean no_backup;
+  public static Level logLevel;
   /** If false, only error/warning output will be generated */
   public static boolean verbose = true;
   /** Whether to show warnings. */

--- a/jflex/src/main/java/jflex/option/Options.java
+++ b/jflex/src/main/java/jflex/option/Options.java
@@ -39,8 +39,6 @@ public class Options {
   /** don't write backup files if this is true */
   public static boolean no_backup;
   public static Level logLevel;
-  /** If false, only error/warning output will be generated */
-  public static boolean verbose = true;
   /** Whether to show warnings. */
   public static boolean warning = true;
   /** Whether to warn about unused macros. */

--- a/jflex/src/main/java/jflex/skeleton/BUILD.bazel
+++ b/jflex/src/main/java/jflex/skeleton/BUILD.bazel
@@ -6,5 +6,6 @@ java_library(
         "//jflex/src/main/java/jflex/exceptions",
         "//jflex/src/main/java/jflex/l10n",
         "//jflex/src/main/java/jflex/logging",
+        "//jflex/src/main/java/jflex/option",
     ],
 )

--- a/jflex/src/main/java/jflex/skeleton/Skeleton.java
+++ b/jflex/src/main/java/jflex/skeleton/Skeleton.java
@@ -24,6 +24,7 @@ import java.util.List;
 import jflex.exceptions.GeneratorException;
 import jflex.l10n.ErrorMessages;
 import jflex.logging.Out;
+import jflex.option.Options;
 
 /**
  * This class stores the skeleton of generated scanners.
@@ -98,8 +99,9 @@ public class Skeleton {
       Out.error(ErrorMessages.CANNOT_READ_SKEL, skeletonFile.toString());
       throw new GeneratorException();
     }
-
-    Out.println(ErrorMessages.READING_SKEL, skeletonFile.toString());
+    if (Options.verbose) {
+      Out.println(ErrorMessages.READING_SKEL, skeletonFile.toString());
+    }
 
     try (BufferedReader reader =
         Files.newBufferedReader(Paths.get(skeletonFile.toString()), UTF_8)) {

--- a/jflex/src/main/java/jflex/skeleton/Skeleton.java
+++ b/jflex/src/main/java/jflex/skeleton/Skeleton.java
@@ -25,7 +25,6 @@ import java.util.logging.Level;
 import jflex.exceptions.GeneratorException;
 import jflex.l10n.ErrorMessages;
 import jflex.logging.Out;
-import jflex.option.Options;
 
 /**
  * This class stores the skeleton of generated scanners.

--- a/jflex/src/main/java/jflex/skeleton/Skeleton.java
+++ b/jflex/src/main/java/jflex/skeleton/Skeleton.java
@@ -21,6 +21,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.logging.Level;
 import jflex.exceptions.GeneratorException;
 import jflex.l10n.ErrorMessages;
 import jflex.logging.Out;
@@ -99,7 +100,7 @@ public class Skeleton {
       Out.error(ErrorMessages.CANNOT_READ_SKEL, skeletonFile.toString());
       throw new GeneratorException();
     }
-    if (Options.verbose) {
+    if (Out.isLogLevel(Level.INFO)) {
       Out.println(ErrorMessages.READING_SKEL, skeletonFile.toString());
     }
 

--- a/jflex/src/test/java/jflex/anttask/JFlexTaskTest.java
+++ b/jflex/src/test/java/jflex/anttask/JFlexTaskTest.java
@@ -125,7 +125,7 @@ public class JFlexTaskTest {
   @Test
   public void testVerbose_true() {
     task.setVerbose(true);
-    assertThat(Options.logLevel).isEqualTo(Level.FINE);
+    assertThat(Options.logLevel).isEqualTo(Level.INFO);
   }
 
   @Test

--- a/jflex/src/test/java/jflex/anttask/JFlexTaskTest.java
+++ b/jflex/src/test/java/jflex/anttask/JFlexTaskTest.java
@@ -15,6 +15,7 @@ import static com.google.common.truth.Truth.assertWithMessage;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.util.logging.Level;
 import jflex.core.OptionUtils;
 import jflex.option.Options;
 import jflex.skeleton.Skeleton;
@@ -116,11 +117,15 @@ public class JFlexTaskTest {
   }
 
   @Test
-  public void testVerbose() {
+  public void testVerbose_false() {
     task.setVerbose(false);
-    assertThat(!Options.verbose).isTrue();
+    assertThat(Options.logLevel).isEqualTo(Level.WARNING);
+  }
+
+  @Test
+  public void testVerbose_true() {
     task.setVerbose(true);
-    assertThat(Options.verbose).isTrue();
+    assertThat(Options.logLevel).isEqualTo(Level.FINE);
   }
 
   @Test


### PR DESCRIPTION
Currently, jflex has options
* `--verbose` which enables `Out.println`
* `--quiet` which negates `--verbose`

Options.verbose and Options.quiet are always the opposite of the other, except in the JflexTestRunner.

This is very confusing and this PR refactors Options and logging:
* Replace the Options.verbose and Options.quiet by Options.logLevel
* To match with current behaviour
  - the log level is WARNING by default
  - `--verbose` increases verbosity to Level.INFO
 * Contrary to current behaviour `--quiet` will reduce verbosity to Level.SEVERE.
   - as needed by the JflexTestRunner
   - as wished by Bazel rule
