### PR TITLE
Fix and re-enabled caseless test

### DIFF
--- a/java/de/jflex/migration/unicodedatatest/testcaseless/UnicodeCaseless.flex.vm
+++ b/java/de/jflex/migration/unicodedatatest/testcaseless/UnicodeCaseless.flex.vm
@@ -42,19 +42,11 @@ import de.jflex.testing.unicodedata.AbstractEnumeratedPropertyDefinedScanner;
   super($maxCodePoint, Integer.class);
 %init}
 
-%{
-  /** @deprecated Legacy method name to make git diff useful. */
-  @Deprecated
-  void print(int codePoint) {
-    setCurCharPropertyValue(yytext(), yylength(), codePoint);
-  }
-%}
-
 %%
 
 <<EOF>>  { return YYEOF; }
 #foreach ( $cp in $caselessCodepoints )
-"\u${cp}" { print(0x${cp}); }
+"\u${cp}" { setCurCharPropertyValue(yytext(), yylength(), 0x${cp}); }
 #end
 
 [^] { }

--- a/java/de/jflex/migration/unicodedatatest/testcaseless/UnicodeCaselessFlexGenerator.java
+++ b/java/de/jflex/migration/unicodedatatest/testcaseless/UnicodeCaselessFlexGenerator.java
@@ -47,8 +47,16 @@ public class UnicodeCaselessFlexGenerator
     UnicodeCaselessFlexTemplateVars vars = new UnicodeCaselessFlexTemplateVars();
     vars.className = "UnicodeCaseless_" + unicodeVersion.underscoreVersion();
     vars.caselessCodepoints =
-        caselessCodepoints.stream().map(cp -> String.format("%04X", cp)).collect(toImmutableList());
+        caselessCodepoints.stream().map(this::formatCodepoint).collect(toImmutableList());
     return vars;
+  }
+
+  private String formatCodepoint(int cp) {
+    if (cp <= 0xFFFF) {
+      return String.format("%04X", cp);
+    } else {
+      return String.format("%06X", cp);
+    }
   }
 
   @Override

--- a/java/de/jflex/migration/unicodedatatest/testcaseless/UnicodeCaselessTest.java.vm
+++ b/java/de/jflex/migration/unicodedatatest/testcaseless/UnicodeCaselessTest.java.vm
@@ -39,7 +39,7 @@ import java.util.List;
 import javax.annotation.Generated;
 import org.junit.Test;
 
-/** Test Tests the {@code %caseless} directive for Unicode ${unicodeVersion}. */
+/** Tests the {@code %caseless} directive for Unicode ${unicodeVersion}. */
 @Generated("de.jflex.migration.unicodedatatest.testcaseless.UnicodeCaseselessTestGenerator")
 public class UnicodeCaselessTest_${unicodeVersion.underscoreVersion()} {
 


### PR DESCRIPTION
Follow-up of #869 

The grammar was incorrectly trying to match \u10400 instead of \u010400