### PR TITLE
Fix blaze option in prepare-deploy-source-code.sh

### DIFF
--- a/scripts/prepare-deploy-source-code.sh
+++ b/scripts/prepare-deploy-source-code.sh
@@ -26,7 +26,7 @@ update_source() {
   gittitle="$1"
   gitlog="$2"
   logi "Updating source for $gittitle"
-  bazel --bazelrc=.ci.bazelrc --remote_http_cache=http://$CIRRUS_HTTP_CACHE_HOST build //jflex:jflex_bin_deploy-src.jar //jflex:resources
+  bazel --bazelrc=.ci.bazelrc build --remote_http_cache=http://$CIRRUS_HTTP_CACHE_HOST //jflex:jflex_bin_deploy-src.jar //jflex:resources
 
   logi "Updating sources from jflex_bin_deploy-src.jar"
   cd repo


### PR DESCRIPTION
[FATAL 12:32:32.066 src/main/cpp/blaze.cc:1289] Unknown startup option: '--remote_http_cache=http://127.0.0.1:12321'.
  For more info, run 'bazel help startup_options'.