### PR TITLE
Disable fmt-maven-plugin plugin Below Java 11

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -2,6 +2,11 @@
 # https://lgtm.com/projects/g/jflex-de/jflex/
 # Format at https://help.semmle.com/lgtm-enterprise/user/help/lgtm.yml-configuration-file.html
 
+extraction:
+  java:
+    # For class file version 55.0
+    java_version: 11
+
 # Note that results for all files classified with a tag are hidden.
 # Path syntax is ant matcher https://confluence.atlassian.com/fisheye/pattern-matching-guide-298976797.html
 path_classifiers:

--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -4,8 +4,9 @@
 
 extraction:
   java:
-    # For class file version 55.0
-    java_version: 11
+    index:
+      # For class file version 55.0
+      java_version: 11
 
 # Note that results for all files classified with a tag are hidden.
 # Path syntax is ant matcher https://confluence.atlassian.com/fisheye/pattern-matching-guide-298976797.html

--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -2,12 +2,6 @@
 # https://lgtm.com/projects/g/jflex-de/jflex/
 # Format at https://help.semmle.com/lgtm-enterprise/user/help/lgtm.yml-configuration-file.html
 
-extraction:
-  java:
-    index:
-      # For class file version 55.0
-      java_version: 11
-
 # Note that results for all files classified with a tag are hidden.
 # Path syntax is ant matcher https://confluence.atlassian.com/fisheye/pattern-matching-guide-298976797.html
 path_classifiers:

--- a/pom.xml
+++ b/pom.xml
@@ -494,7 +494,7 @@
     <profile>
       <id>format-java</id>
       <activation>
-        <jdk>[1.8,)</jdk>
+        <jdk>[11,)</jdk>
         <property>
           <name>!env.CI</name>
         </property>


### PR DESCRIPTION
Semmle LGTM analysis is currently broken with

> [autobuild] java.lang.UnsupportedClassVersionError: com/google/googlejavaformat/java/FormatterException has been compiled by a more recent version of the Java Runtime (class file version 55.0), this version of the Java Runtime only recognizes class file versions up to 52.0
>     at java.lang.ClassLoader.defineClass1 (Native Method)

Probably following #909

This PR enables the profile on Java 11+, as required by the plugin.