### PR TITLE
jflex pom: add inline m2e lifecycle mapping

### DIFF
--- a/jflex/pom.xml
+++ b/jflex/pom.xml
@@ -124,6 +124,7 @@
         <version>1.8.2</version>
         <executions>
           <execution>
+            <?m2e execute onConfiguration,onIncremental?>
             <goals>
               <goal>generate</goal>
             </goals>
@@ -138,6 +139,7 @@
         <artifactId>cup-maven-plugin</artifactId>
         <executions>
           <execution>
+            <?m2e execute onConfiguration,onIncremental?>
             <goals>
               <goal>generate</goal>
             </goals>


### PR DESCRIPTION
This makes it easier to work with VSCode etc. Should add a corresponding lifecycle mapping XML file to the CUP and jflex plugins later.