### PR TITLE
pom: fix maven-shade-plugin errors

### DIFF
--- a/cup-maven-plugin/pom.xml
+++ b/cup-maven-plugin/pom.xml
@@ -41,10 +41,12 @@
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-core</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.plugin-tools</groupId>

--- a/jflex-maven-plugin/pom.xml
+++ b/jflex-maven-plugin/pom.xml
@@ -93,10 +93,12 @@
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-core</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.plugin-tools</groupId>

--- a/testsuite/jflex-testsuite-maven-plugin/pom.xml
+++ b/testsuite/jflex-testsuite-maven-plugin/pom.xml
@@ -99,6 +99,13 @@
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-artifact</artifactId>
+      <version>3.5.2</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>de.jflex</groupId>


### PR DESCRIPTION
> Some dependencies of Maven Plugins are expected to be in provided scope.
Please make sure that dependencies listed below declared in POM
have set '<scope>provided</scope>' as well.
