### PR TITLE
testsuite: sync verbosity behaviour with main jflex

### DIFF
--- a/java/de/jflex/testing/testsuite/JFlexTestRunner.java
+++ b/java/de/jflex/testing/testsuite/JFlexTestRunner.java
@@ -204,7 +204,19 @@ public class JFlexTestRunner extends BlockJUnit4ClassRunner {
     }
     Options.jlex = spec.jlexCompat();
     Options.dump = spec.dump();
-    Options.verbose = !spec.quiet();
+    // verbose is default -- verbose_provided simulates the behaviour of an explicit -v on the
+    // command line
+    if (spec.verbose_provided()) {
+      Options.verbose = true;
+      Options.progress = true;
+      Options.unused_warning = true;
+    }
+    // if both verbose_provided() and quiet() are present, we want quiet() to win
+    if (spec.quiet()) {
+      Options.verbose = false;
+      Options.progress = false;
+      Options.unused_warning = false;
+    }
     Options.unused_warning = spec.warnUnused();
     LexGenerator lexGenerator = new LexGenerator(new File(spec.lex()));
     String lexerJavaFileName = checkNotNull(lexGenerator.generate());

--- a/java/de/jflex/testing/testsuite/annotations/TestSpec.java
+++ b/java/de/jflex/testing/testsuite/annotations/TestSpec.java
@@ -63,6 +63,9 @@ public @interface TestSpec {
   /** Runs JFlex generation with the {@code -q} option. */
   boolean quiet() default false;
 
+  /** Explicitly run JFlex with the {@code -v} option (even though verbose mode is default). */
+  boolean verbose_provided() default false;
+
   /** Golden file for JFlex's log (System.out stream). */
   String sysout() default "";
 

--- a/jflex/src/main/java/jflex/core/AbstractLexScan.java
+++ b/jflex/src/main/java/jflex/core/AbstractLexScan.java
@@ -372,7 +372,7 @@ public abstract class AbstractLexScan implements ILexScan {
   }
 
   /**
-   * @deprecated Use {@link #columnCoount}
+   * @deprecated Use {@link #columnCount}
    */
   @SuppressWarnings("unused") // Used by generated LexScan
   @Deprecated


### PR DESCRIPTION
Simpler version of #880 without introducing log levels in the same go.

(not that log levels don't make sense, just should be separate)