### PR TITLE
make char classes robust against input char set size

### DIFF
--- a/javatests/de/jflex/testcase/ccl_caseless/BUILD.bazel
+++ b/javatests/de/jflex/testcase/ccl_caseless/BUILD.bazel
@@ -1,0 +1,48 @@
+# This build file was generated automatically, but won't be re-generated.
+# Feel free to improve.
+
+load("@jflex_rules//jflex:jflex.bzl", "jflex")
+load("//scripts:check_deps.bzl", "check_deps")
+
+check_deps(
+    name = "deps_to_bootstrap_jflex_test",
+    prohibited = "@jflex_rules//jflex:jflex_bin",
+)
+
+# ccl_caseless
+
+jflex(
+    name = "gen_ccl_caseless_scanner",
+    srcs = ["ccl_caseless.flex"],
+    jflex_bin = "//jflex:jflex_bin",
+    outputs = ["Ccl_caseless.java"],
+)
+
+java_library(
+    name = "ccl_caseless_scanner",
+    srcs = [
+        ":gen_ccl_caseless_scanner",
+    ],
+    deps = [
+        "//third_party/com/google/guava",
+    ],
+)
+
+java_test(
+    name = "Ccl_caselessGoldenTest",
+    size = "small",
+    srcs = [
+        "Ccl_caselessGoldenTest.java",
+    ],
+    data = [
+        "ccl_caseless-0.input",
+        "ccl_caseless-0.output",
+    ],
+    deps = [
+        ":ccl_caseless_scanner",
+        "//java/de/jflex/testing/testsuite/golden",
+        "//java/de/jflex/util/scanner:scanner_factory",
+        "//third_party/com/google/guava",
+        "//third_party/com/google/truth",
+    ],
+)

--- a/javatests/de/jflex/testcase/ccl_caseless/Ccl_caselessGoldenTest.java
+++ b/javatests/de/jflex/testcase/ccl_caseless/Ccl_caselessGoldenTest.java
@@ -1,0 +1,38 @@
+// test: ccl_caseless
+
+package de.jflex.testcase.ccl_caseless;
+
+import de.jflex.testing.testsuite.golden.AbstractGoldenTest;
+import de.jflex.testing.testsuite.golden.GoldenInOutFilePair;
+import de.jflex.util.scanner.ScannerFactory;
+import java.io.File;
+import org.junit.Test;
+
+/**
+ * Test for issue <a href"https://github.com/jflex-de/jflex/issues/974">#974 Unexpected exception
+ * encountered in JFlex</a>.
+ *
+ * <p>Tests that the generated scanner can handle case-insensitive character classes with characters
+ * outside the current input char set.
+ */
+public class Ccl_caselessGoldenTest extends AbstractGoldenTest {
+
+  /** Creates a scanner conforming to the {@code ccl_caseless.flex} specification. */
+  private final ScannerFactory<Ccl_caseless> scannerFactory = ScannerFactory.of(Ccl_caseless::new);
+
+  private final File testRuntimeDir = new File("javatests/de/jflex/testcase/ccl_caseless");
+
+  @Test
+  public void goldenTest0() throws Exception {
+    GoldenInOutFilePair golden =
+        new GoldenInOutFilePair(
+            new File(testRuntimeDir, "ccl_caseless-0.input"),
+            new File(testRuntimeDir, "ccl_caseless-0.output"));
+    compareSystemOutWith(golden);
+
+    Ccl_caseless scanner = scannerFactory.createScannerForFile(golden.inputFile);
+    while (!scanner.yyatEOF()) {
+      System.out.println(scanner.yylex());
+    }
+  }
+}

--- a/javatests/de/jflex/testcase/ccl_caseless/ccl_caseless-0.input
+++ b/javatests/de/jflex/testcase/ccl_caseless/ccl_caseless-0.input
@@ -1,0 +1,1 @@
+asbcSba

--- a/javatests/de/jflex/testcase/ccl_caseless/ccl_caseless-0.output
+++ b/javatests/de/jflex/testcase/ccl_caseless/ccl_caseless-0.output
@@ -1,0 +1,13 @@
+match: --a--
+action [17] { /* default */ }
+match: --sb--
+action [15] { return 1; }
+1
+match: --c--
+action [17] { /* default */ }
+match: --Sb--
+action [15] { return 1; }
+1
+match: --a--
+action [17] { /* default */ }
+-1

--- a/javatests/de/jflex/testcase/ccl_caseless/ccl_caseless.flex
+++ b/javatests/de/jflex/testcase/ccl_caseless/ccl_caseless.flex
@@ -1,0 +1,17 @@
+package de.jflex.testcase.ccl_caseless;
+
+%%
+
+%public
+%class Ccl_caseless
+%int
+%debug
+
+%full
+%caseless
+
+%%
+
+sb { return 1; }
+
+[^] { /* default */ }

--- a/jflex/src/main/java/jflex/core/Macros.java
+++ b/jflex/src/main/java/jflex/core/Macros.java
@@ -125,7 +125,7 @@ public final class Macros {
    * @throws MacroException if there is a cycle in the macro usage graph.
    */
   public void expand() throws MacroException {
-    Set<String> keys = new HashSet(macros.keySet());
+    Set<String> keys = new HashSet<String>(macros.keySet());
     for (String name : keys) {
       if (isUsed(name)) {
         macros.replace(name, expandMacro(name, getDefinition(name)));

--- a/jflex/src/main/java/jflex/core/NFA.java
+++ b/jflex/src/main/java/jflex/core/NFA.java
@@ -307,6 +307,10 @@ public final class NFA {
   public void addTransition(int start, int input, int dest) {
     Out.debug("Adding transition (" + start + ", " + input + ", " + dest + ")");
 
+    // Trying to insert a transition for a character that is not in the input
+    // char set. Ignore it. This can happen for case insensitive matching.
+    if (input == -1) return;
+
     int maxS = Math.max(start, dest) + 1;
 
     ensureCapacity(maxS);

--- a/jflex/src/main/java/jflex/core/unicode/CharClasses.java
+++ b/jflex/src/main/java/jflex/core/unicode/CharClasses.java
@@ -184,15 +184,17 @@ public class CharClasses {
   /**
    * Returns the code of the character class the specified character belongs to.
    *
-   * @param codePoint code point.
-   * @return code of the character class.
+   * @param codePoint code point to get the char class for.
+   * @return code of the character class, -1 if {@code codePoint} is not in the input char set.
    */
   public int getClassCode(int codePoint) {
-    int i = -1;
-    while (true) {
-      IntCharSet x = classes.get(++i);
+    int i = 0;
+    while (i < classes.size()) {
+      IntCharSet x = classes.get(i);
       if (x.contains(codePoint)) return i;
+      i++;
     }
+    return -1;
   }
 
   /**

--- a/jflex/src/test/java/jflex/dfa/DfaTest.java
+++ b/jflex/src/test/java/jflex/dfa/DfaTest.java
@@ -7,6 +7,7 @@ import org.junit.Test;
 public class DfaTest {
 
   @Test
+  @SuppressWarnings("deprecation")
   public void copyOf() {
     DFA dfa1 = new DFA(2, 1, 1);
     DFA dfa2 = DeprecatedDfa.copyOf(dfa1);

--- a/jflex/src/test/java/jflex/state/StateSetQuickcheck.java
+++ b/jflex/src/test/java/jflex/state/StateSetQuickcheck.java
@@ -12,6 +12,7 @@ package jflex.state;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
 import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeThat;
 import static org.junit.Assume.assumeTrue;
 
@@ -245,6 +246,11 @@ public class StateSetQuickcheck {
   @Property
   public void complementNoOriginalElements(StateSet s1, StateSet s2) {
     StateSet comp = s1.complement(s2);
+    if (comp == null) {
+      fail("complement returned null");
+      return; // unreachable; makes non-nullable check happy
+    }
+
     // no elements of s1 are in the complement
     comp.intersect(s1);
     assertThat(comp).isEmpty();
@@ -253,6 +259,11 @@ public class StateSetQuickcheck {
   @Property
   public void complementElements(StateSet s1, StateSet s2) {
     StateSet comp = s1.complement(s2);
+    if (comp == null) {
+      fail("complement returned null");
+      return; // unreachable; makes non-nullable check happy
+    }
+
     // only elements of s2 are in the complement
     assertThat(s2.contains(comp)).isTrue();
 


### PR DESCRIPTION
In `%caseless` mode, char classes can contain characters that are not in the input char set, leading to an exception when we try to look up the class code for such a character.

- add a regression test case for this situation
- make CharClasses robust against this situation and ignores characters outside the input char set in NFA construction.
- minor warning reductions

Fixes #974