### PR TITLE
jflex UnicodeProperties: remove warning

### DIFF
--- a/jflex/src/main/java/jflex/core/unicode/UnicodeProperties.java
+++ b/jflex/src/main/java/jflex/core/unicode/UnicodeProperties.java
@@ -445,7 +445,9 @@ public class UnicodeProperties {
         singleLetterPropValueSet.add(set);
       }
     }
-    for (int n = 0; n < propertyValueAliases.length; n += 2) {
+    // We expect the length of propertyValueAliases to be divisible by 2 (alias/value pairs)
+    assert 0 == propertyValueAliases.length % 2;
+    for (int n = 0; n < propertyValueAliases.length - 1; n += 2) {
       String alias = propertyValueAliases[n];
       String propertyValue = propertyValueAliases[n + 1];
       IntCharSet targetSet = propertyValueIntervals.get(propertyValue);


### PR DESCRIPTION
Remove ArrayIndexOutOfBounds warning. We know the array has a length divisible by 2, so the access is not actually out of bounds. Comparing to `length - 1` instead of `length` makes the static analysis happy.

Should placate https://github.com/jflex-de/jflex/security/code-scanning/42