### PR TITLE
jflex: make ErrorMessages a real enum

### DIFF
--- a/jflex/src/main/cup/LexParse.cup
+++ b/jflex/src/main/cup/LexParse.cup
@@ -33,29 +33,29 @@ action code {:
   EOFActions  eofActions  = new EOFActions();
   Map<Integer,IntCharSet> preclassCache = new HashMap<Integer,IntCharSet>();
 
-  void fatalError(ErrorMessages.ErrorMessage message, int line, int col) {
+  void fatalError(ErrorMessages message, int line, int col) {
     syntaxError(message, line, col);
     throw new GeneratorException();
   }
 
-  void fatalError(ErrorMessages.ErrorMessage message) {
+  void fatalError(ErrorMessages message) {
     fatalError(message, scanner.lexLine(), -1);
     throw new GeneratorException();
   }
 
-  void syntaxError(ErrorMessages.ErrorMessage message) {
+  void syntaxError(ErrorMessages message) {
     Out.error(scanner.file, message, scanner.lexLine(), -1);
   }
 
-  void syntaxError(ErrorMessages.ErrorMessage message, int line) {
+  void syntaxError(ErrorMessages message, int line) {
     Out.error(scanner.file, message, line, -1);
   }
 
-  void syntaxError(ErrorMessages.ErrorMessage message, int line, int col) {
+  void syntaxError(ErrorMessages message, int line, int col) {
     Out.error(scanner.file, message, line, col);
   }
 
-  void warning(ErrorMessages.ErrorMessage message, int line, int col) {
+  void warning(ErrorMessages message, int line, int col) {
     Out.warning(scanner.file, message, line, col);
   }
 

--- a/jflex/src/main/java/jflex/l10n/ErrorMessages.java
+++ b/jflex/src/main/java/jflex/l10n/ErrorMessages.java
@@ -1,199 +1,105 @@
 /*
- * Copyright (C) 1998-2018  Gerwin Klein <lsf@jflex.de>
+ * Copyright (C) 1998-2023  Gerwin Klein <lsf@jflex.de>
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
 package jflex.l10n;
 
 import java.text.MessageFormat;
-import java.util.MissingResourceException;
 import java.util.ResourceBundle;
 
 /**
- * Central class for all kinds of JFlex messages.
+ * Central enum for all kinds of JFlex messages.
  *
- * <p>[Is not yet used exclusively, but should]
+ * <p>The enum values are expected to be keys in the {@code Messages.properties} resource bundle.
  *
  * @author Gerwin Klein
  * @version JFlex 1.9.0-SNAPSHOT
  */
-public class ErrorMessages {
-
-  private ErrorMessages() {}
-
-  // typesafe enumeration (generated, do not edit)
-  /** Constant {@code UNTERMINATED_STR} */
-  public static ErrorMessage UNTERMINATED_STR = new ErrorMessage("UNTERMINATED_STR");
-  /** Constant {@code EOF_WO_ACTION} */
-  public static ErrorMessage EOF_WO_ACTION = new ErrorMessage("EOF_WO_ACTION");
-  /** Constant {@code UNKNOWN_OPTION} */
-  public static ErrorMessage UNKNOWN_OPTION = new ErrorMessage("UNKNOWN_OPTION");
-  /** Constant {@code UNEXPECTED_CHAR} */
-  public static ErrorMessage UNEXPECTED_CHAR = new ErrorMessage("UNEXPECTED_CHAR");
-  /** Constant {@code UNEXPECTED_NL} */
-  public static ErrorMessage UNEXPECTED_NL = new ErrorMessage("UNEXPECTED_NL");
-  /** Constant {@code LEXSTATE_UNDECL} */
-  public static ErrorMessage LEXSTATE_UNDECL = new ErrorMessage("LEXSTATE_UNDECL");
-  /** Constant {@code REPEAT_ZERO} */
-  public static ErrorMessage REPEAT_ZERO = new ErrorMessage("REPEAT_ZERO");
-  /** Constant {@code REPEAT_GREATER} */
-  public static ErrorMessage REPEAT_GREATER = new ErrorMessage("REPEAT_GREATER");
-  /** Constant {@code REGEXP_EXPECTED} */
-  public static ErrorMessage REGEXP_EXPECTED = new ErrorMessage("REGEXP_EXPECTED");
-  /** Constant {@code MACRO_UNDECL} */
-  public static ErrorMessage MACRO_UNDECL = new ErrorMessage("MACRO_UNDECL");
-  /** Constant {@code CHARSET_2_SMALL} */
-  public static ErrorMessage CHARSET_2_SMALL = new ErrorMessage("CHARSET_2_SMALL");
-  /** Constant {@code CS2SMALL_STRING} */
-  public static ErrorMessage CS2SMALL_STRING = new ErrorMessage("CS2SMALL_STRING");
-  /** Constant {@code CS2SMALL_CHAR} */
-  public static ErrorMessage CS2SMALL_CHAR = new ErrorMessage("CS2SMALL_CHAR");
-  /** Constant {@code CHARCLASS_MACRO} */
-  public static ErrorMessage CHARCLASS_MACRO = new ErrorMessage("CHARCLASS_MACRO");
-  /** Constant {@code UNKNOWN_SYNTAX} */
-  public static ErrorMessage UNKNOWN_SYNTAX = new ErrorMessage("UNKNOWN_SYNTAX");
-  /** Constant {@code SYNTAX_ERROR} */
-  public static ErrorMessage SYNTAX_ERROR = new ErrorMessage("SYNTAX_ERROR");
-  /** Constant {@code NOT_AT_BOL} */
-  public static ErrorMessage NOT_AT_BOL = new ErrorMessage("NOT_AT_BOL");
-  /** Constant {@code EOF_IN_ACTION} */
-  public static ErrorMessage EOF_IN_ACTION = new ErrorMessage("EOF_IN_ACTION");
-  /** Constant {@code EOF_IN_COMMENT} */
-  public static ErrorMessage EOF_IN_COMMENT = new ErrorMessage("EOF_IN_COMMENT");
-  /** Constant {@code EOF_IN_STRING} */
-  public static ErrorMessage EOF_IN_STRING = new ErrorMessage("EOF_IN_STRING");
-  /** Constant {@code EOF_IN_MACROS} */
-  public static ErrorMessage EOF_IN_MACROS = new ErrorMessage("EOF_IN_MACROS");
-  /** Constant {@code EOF_IN_STATES} */
-  public static ErrorMessage EOF_IN_STATES = new ErrorMessage("EOF_IN_STATES");
-  /** Constant {@code EOF_IN_REGEXP} */
-  public static ErrorMessage EOF_IN_REGEXP = new ErrorMessage("EOF_IN_REGEXP");
-  /** Constant {@code UNEXPECTED_EOF} */
-  public static ErrorMessage UNEXPECTED_EOF = new ErrorMessage("UNEXPECTED_EOF");
-  /** Constant {@code NO_LEX_SPEC} */
-  public static ErrorMessage NO_LEX_SPEC = new ErrorMessage("NO_LEX_SPEC");
-  /** Constant {@code NO_LAST_ACTION} */
-  public static ErrorMessage NO_LAST_ACTION = new ErrorMessage("NO_LAST_ACTION");
-  /** Constant {@code NO_DIRECTORY} */
-  public static ErrorMessage NO_DIRECTORY = new ErrorMessage("NO_DIRECTORY");
-  /** Constant {@code NO_SKEL_FILE} */
-  public static ErrorMessage NO_SKEL_FILE = new ErrorMessage("NO_SKEL_FILE");
-  /** Constant {@code WRONG_SKELETON} */
-  public static ErrorMessage WRONG_SKELETON = new ErrorMessage("WRONG_SKELETON");
-  /** Constant {@code OUT_OF_MEMORY} */
-  public static ErrorMessage OUT_OF_MEMORY = new ErrorMessage("OUT_OF_MEMORY");
-  /** Constant {@code QUIL_INITTHROW} */
-  public static ErrorMessage QUIL_INITTHROW = new ErrorMessage("QUIL_INITTHROW");
-  /** Constant {@code QUIL_EOFTHROW} */
-  public static ErrorMessage QUIL_EOFTHROW = new ErrorMessage("QUIL_EOFTHROW");
-  /** Constant {@code QUIL_YYLEXTHROW} */
-  public static ErrorMessage QUIL_YYLEXTHROW = new ErrorMessage("QUIL_YYLEXTHROW");
-  /** Constant {@code ZERO_STATES} */
-  public static ErrorMessage ZERO_STATES = new ErrorMessage("ZERO_STATES");
-  /** Constant {@code NO_BUFFER_SIZE} */
-  public static ErrorMessage NO_BUFFER_SIZE = new ErrorMessage("NO_BUFFER_SIZE");
-  /** Constant {@code NOT_READABLE} */
-  public static ErrorMessage NOT_READABLE = new ErrorMessage("NOT_READABLE");
-  /** Constant {@code FILE_CYCLE} */
-  public static ErrorMessage FILE_CYCLE = new ErrorMessage("FILE_CYCLE");
-  /** Constant {@code FILE_WRITE} */
-  public static ErrorMessage FILE_WRITE = new ErrorMessage("FILE_WRITE");
-  /** Constant {@code QUIL_SCANERROR} */
-  public static ErrorMessage QUIL_SCANERROR = new ErrorMessage("QUIL_SCANERROR");
-  /** Constant {@code NEVER_MATCH} */
-  public static ErrorMessage NEVER_MATCH = new ErrorMessage("NEVER_MATCH");
-  /** Constant {@code QUIL_THROW} */
-  public static ErrorMessage QUIL_THROW = new ErrorMessage("QUIL_THROW");
-  /** Constant {@code EOL_IN_CHARCLASS} */
-  public static ErrorMessage EOL_IN_CHARCLASS = new ErrorMessage("EOL_IN_CHARCLASS");
-  /** Constant {@code QUIL_CUPSYM} */
-  public static ErrorMessage QUIL_CUPSYM = new ErrorMessage("QUIL_CUPSYM");
-  /** Constant {@code CUPSYM_AFTER_CUP} */
-  public static ErrorMessage CUPSYM_AFTER_CUP = new ErrorMessage("CUPSYM_AFTER_CUP");
-  /** Constant {@code ALREADY_RUNNING} */
-  public static ErrorMessage ALREADY_RUNNING = new ErrorMessage("ALREADY_RUNNING");
-  /** Constant {@code CANNOT_READ_SKEL} */
-  public static ErrorMessage CANNOT_READ_SKEL = new ErrorMessage("CANNOT_READ_SKEL");
-  /** Constant {@code READING_SKEL} */
-  public static ErrorMessage READING_SKEL = new ErrorMessage("READING_SKEL");
-  /** Constant {@code SKEL_IO_ERROR} */
-  public static ErrorMessage SKEL_IO_ERROR = new ErrorMessage("SKEL_IO_ERROR");
-  /** Constant {@code SKEL_IO_ERROR_DEFAULT} */
-  public static ErrorMessage SKEL_IO_ERROR_DEFAULT = new ErrorMessage("SKEL_IO_ERROR_DEFAULT");
-  /** Constant {@code READING} */
-  public static ErrorMessage READING = new ErrorMessage("READING");
-  /** Constant {@code CANNOT_OPEN} */
-  public static ErrorMessage CANNOT_OPEN = new ErrorMessage("CANNOT_OPEN");
-  /** Constant {@code NFA_IS} */
-  public static ErrorMessage NFA_IS = new ErrorMessage("NFA_IS");
-  /** Constant {@code NFA_STATES} */
-  public static ErrorMessage NFA_STATES = new ErrorMessage("NFA_STATES");
-  /** Constant {@code DFA_TOOK} */
-  public static ErrorMessage DFA_TOOK = new ErrorMessage("DFA_TOOK");
-  /** Constant {@code DFA_IS} */
-  public static ErrorMessage DFA_IS = new ErrorMessage("DFA_IS");
-  /** Constant {@code MIN_TOOK} */
-  public static ErrorMessage MIN_TOOK = new ErrorMessage("MIN_TOOK");
-  /** Constant {@code MIN_DFA_IS} */
-  public static ErrorMessage MIN_DFA_IS = new ErrorMessage("MIN_DFA_IS");
-  /** Constant {@code WRITE_TOOK} */
-  public static ErrorMessage WRITE_TOOK = new ErrorMessage("WRITE_TOOK");
-  /** Constant {@code TOTAL_TIME} */
-  public static ErrorMessage TOTAL_TIME = new ErrorMessage("TOTAL_TIME");
-  /** Constant {@code IO_ERROR} */
-  public static ErrorMessage IO_ERROR = new ErrorMessage("IO_ERROR");
-  /** Constant {@code THIS_IS_JFLEX} */
-  public static ErrorMessage THIS_IS_JFLEX = new ErrorMessage("THIS_IS_JFLEX");
-  /** Constant {@code UNKNOWN_COMMANDLINE} */
-  public static ErrorMessage UNKNOWN_COMMANDLINE = new ErrorMessage("UNKNOWN_COMMANDLINE");
-  /** Constant {@code MACRO_CYCLE} */
-  public static ErrorMessage MACRO_CYCLE = new ErrorMessage("MACRO_CYCLE");
-  /** Constant {@code MACRO_DEF_MISSING} */
-  public static ErrorMessage MACRO_DEF_MISSING = new ErrorMessage("MACRO_DEF_MISSING");
-  /** Constant {@code PARSING_TOOK} */
-  public static ErrorMessage PARSING_TOOK = new ErrorMessage("PARSING_TOOK");
-  /** Constant {@code NFA_TOOK} */
-  public static ErrorMessage NFA_TOOK = new ErrorMessage("NFA_TOOK");
-  /** Constant {@code LOOKAHEAD_NEEDS_ACTION} */
-  public static ErrorMessage LOOKAHEAD_NEEDS_ACTION = new ErrorMessage("LOOKAHEAD_NEEDS_ACTION");
-  /** Constant {@code EMPTY_MATCH} */
-  public static ErrorMessage EMPTY_MATCH = new ErrorMessage("EMPTY_MATCH");
-  /** Constant {@code EMPTY_MATCH_LOOK} */
-  public static ErrorMessage EMPTY_MATCH_LOOK = new ErrorMessage("EMPTY_MATCH_LOOK");
-  /** Constant {@code CTOR_ARG} */
-  public static ErrorMessage CTOR_ARG = new ErrorMessage("CTOR_ARG");
-  /** Constant {@code CTOR_DEBUG} */
-  public static ErrorMessage CTOR_DEBUG = new ErrorMessage("CTOR_DEBUG");
-  /** Constant {@code INT_AND_TYPE} */
-  public static ErrorMessage INT_AND_TYPE = new ErrorMessage("INT_AND_TYPE");
-  /** Constant {@code UNSUPPORTED_UNICODE_VERSION} */
-  public static ErrorMessage UNSUPPORTED_UNICODE_VERSION =
-      new ErrorMessage("UNSUPPORTED_UNICODE_VERSION");
-  /** Constant {@code UNSUPPORTED_UNICODE_VERSION_SUPPORTED_ARE} */
-  public static ErrorMessage UNSUPPORTED_UNICODE_VERSION_SUPPORTED_ARE =
-      new ErrorMessage("UNSUPPORTED_UNICODE_VERSION_SUPPORTED_ARE");
-  /** Constant {@code INVALID_UNICODE_PROPERTY} */
-  public static ErrorMessage INVALID_UNICODE_PROPERTY =
-      new ErrorMessage("INVALID_UNICODE_PROPERTY");
-  /** Constant {@code DOT_BAR_NEWLINE_DOES_NOT_MATCH_ALL_CHARS} */
-  public static ErrorMessage DOT_BAR_NEWLINE_DOES_NOT_MATCH_ALL_CHARS =
-      new ErrorMessage("DOT_BAR_NEWLINE_DOES_NOT_MATCH_ALL_CHARS");
-  /** Constant {@code PROPS_ARG_REQUIRES_UNICODE_VERSION} */
-  public static ErrorMessage PROPS_ARG_REQUIRES_UNICODE_VERSION =
-      new ErrorMessage("PROPS_ARG_REQUIRES_UNICODE_VERSION");
-  /** Constant {@code IMPOSSIBLE_CHARCLASS_RANGE} */
-  public static ErrorMessage IMPOSSIBLE_CHARCLASS_RANGE =
-      new ErrorMessage("IMPOSSIBLE_CHARCLASS_RANGE");
-  /** Constant {@code CODEPOINT_OUT_OF_RANGE} */
-  public static ErrorMessage CODEPOINT_OUT_OF_RANGE = new ErrorMessage("CODEPOINT_OUT_OF_RANGE");
-  /** Constant {@code NO_ENCODING} */
-  public static ErrorMessage NO_ENCODING = new ErrorMessage("NO_ENCODING");
-  /** Constant {@code CHARSET_NOT_SUPPORTED} */
-  public static ErrorMessage CHARSET_NOT_SUPPORTED = new ErrorMessage("CHARSET_NOT_SUPPORTED");
-  /** Constant {@code DOUBLE_CHARSET} */
-  public static ErrorMessage DOUBLE_CHARSET = new ErrorMessage("DOUBLE_CHARSET");
-  /** Constant {@code NOT_CHARCLASS} */
-  public static ErrorMessage NOT_CHARCLASS = new ErrorMessage("NOT_CHARCLASS");
+public enum ErrorMessages {
+  UNTERMINATED_STR,
+  EOF_WO_ACTION,
+  UNKNOWN_OPTION,
+  UNEXPECTED_CHAR,
+  UNEXPECTED_NL,
+  LEXSTATE_UNDECL,
+  REPEAT_ZERO,
+  REPEAT_GREATER,
+  REGEXP_EXPECTED,
+  MACRO_UNDECL,
+  CHARSET_2_SMALL,
+  CS2SMALL_STRING,
+  CS2SMALL_CHAR,
+  CHARCLASS_MACRO,
+  UNKNOWN_SYNTAX,
+  SYNTAX_ERROR,
+  NOT_AT_BOL,
+  EOF_IN_ACTION,
+  EOF_IN_COMMENT,
+  EOF_IN_STRING,
+  EOF_IN_MACROS,
+  EOF_IN_STATES,
+  EOF_IN_REGEXP,
+  UNEXPECTED_EOF,
+  NO_LEX_SPEC,
+  NO_LAST_ACTION,
+  NO_DIRECTORY,
+  NO_SKEL_FILE,
+  WRONG_SKELETON,
+  OUT_OF_MEMORY,
+  QUIL_INITTHROW,
+  QUIL_EOFTHROW,
+  QUIL_YYLEXTHROW,
+  ZERO_STATES,
+  NO_BUFFER_SIZE,
+  NOT_READABLE,
+  FILE_CYCLE,
+  FILE_WRITE,
+  QUIL_SCANERROR,
+  NEVER_MATCH,
+  QUIL_THROW,
+  EOL_IN_CHARCLASS,
+  QUIL_CUPSYM,
+  CUPSYM_AFTER_CUP,
+  ALREADY_RUNNING,
+  CANNOT_READ_SKEL,
+  READING_SKEL,
+  SKEL_IO_ERROR,
+  SKEL_IO_ERROR_DEFAULT,
+  READING,
+  CANNOT_OPEN,
+  NFA_IS,
+  NFA_STATES,
+  DFA_TOOK,
+  DFA_IS,
+  MIN_TOOK,
+  MIN_DFA_IS,
+  WRITE_TOOK,
+  TOTAL_TIME,
+  IO_ERROR,
+  THIS_IS_JFLEX,
+  UNKNOWN_COMMANDLINE,
+  MACRO_CYCLE,
+  MACRO_DEF_MISSING,
+  PARSING_TOOK,
+  NFA_TOOK,
+  LOOKAHEAD_NEEDS_ACTION,
+  EMPTY_MATCH,
+  EMPTY_MATCH_LOOK,
+  CTOR_ARG,
+  CTOR_DEBUG,
+  INT_AND_TYPE,
+  UNSUPPORTED_UNICODE_VERSION,
+  UNSUPPORTED_UNICODE_VERSION_SUPPORTED_ARE,
+  INVALID_UNICODE_PROPERTY,
+  DOT_BAR_NEWLINE_DOES_NOT_MATCH_ALL_CHARS,
+  PROPS_ARG_REQUIRES_UNICODE_VERSION,
+  IMPOSSIBLE_CHARCLASS_RANGE,
+  CODEPOINT_OUT_OF_RANGE,
+  NO_ENCODING,
+  CHARSET_NOT_SUPPORTED,
+  DOUBLE_CHARSET,
+  NOT_CHARCLASS;
 
   /* not final static, because initializing here seems too early
    * for OS/2 JDK 1.1.8. See bug 1065521.
@@ -206,15 +112,13 @@ public class ErrorMessages {
    * @param msg a {@link ErrorMessages} object.
    * @return a {@link java.lang.String} representation of the errors.
    */
-  public static String get(ErrorMessage msg) {
+  public static String get(ErrorMessages msg) {
     if (resourceBundle == null) {
       resourceBundle = ResourceBundle.getBundle("jflex.Messages");
     }
-    try {
-      return resourceBundle.getString(msg.key);
-    } catch (MissingResourceException e) {
-      return '!' + msg.key + '!';
-    }
+    // not catching MissingResourceException -- if this fails, we want the
+    // exception to reach the top level and be reported to the user as a bug.
+    return resourceBundle.getString(msg.toString());
   }
 
   /**
@@ -223,15 +127,7 @@ public class ErrorMessages {
    * @param msg a {@link ErrorMessages} containing the format string.
    * @return a {@link java.lang.String} object.
    */
-  public static String get(ErrorMessages.ErrorMessage msg, Object... args) {
+  public static String get(ErrorMessages msg, Object... args) {
     return MessageFormat.format(get(msg), args);
-  }
-
-  public static class ErrorMessage {
-    private final String key;
-
-    private ErrorMessage(String key) {
-      this.key = key;
-    }
   }
 }

--- a/jflex/src/main/java/jflex/logging/Out.java
+++ b/jflex/src/main/java/jflex/logging/Out.java
@@ -72,7 +72,7 @@ public final class Out {
    * @param message the message to be printed
    * @param time elapsed time
    */
-  public static void time(ErrorMessages.ErrorMessage message, Timer time) {
+  public static void time(ErrorMessages message, Timer time) {
     if (Options.time) {
       String msg = ErrorMessages.get(message, time.toString());
       out.println(msg);
@@ -107,7 +107,7 @@ public final class Out {
    * @param message the message to be printed
    * @param data data to be inserted into the message
    */
-  public static void println(ErrorMessages.ErrorMessage message, String data) {
+  public static void println(ErrorMessages message, String data) {
     if (Options.verbose) {
       out.println(ErrorMessages.get(message, data));
     }
@@ -119,7 +119,7 @@ public final class Out {
    * @param message the message to be printed
    * @param data data to be inserted into the message
    */
-  public static void println(ErrorMessages.ErrorMessage message, int data) {
+  public static void println(ErrorMessages message, int data) {
     if (Options.verbose) {
       out.println(ErrorMessages.get(message, data));
     }
@@ -213,7 +213,7 @@ public final class Out {
    * @param message code of the warning message
    * @see ErrorMessages
    */
-  public static void warning(ErrorMessages.ErrorMessage message) {
+  public static void warning(ErrorMessages message) {
     warning(message, 0);
   }
 
@@ -224,7 +224,7 @@ public final class Out {
    * @param line the line information
    * @see ErrorMessages
    */
-  public static void warning(ErrorMessages.ErrorMessage message, int line) {
+  public static void warning(ErrorMessages message, int line) {
     warnings++;
 
     String msg = NL + "Warning";
@@ -241,7 +241,7 @@ public final class Out {
    * @param line the line number of the position
    * @param column the column of the position
    */
-  public static void warning(File file, ErrorMessages.ErrorMessage message, int line, int column) {
+  public static void warning(File file, ErrorMessages message, int line, int column) {
 
     String msg = NL + "Warning";
     if (file != null) msg += " in file \"" + file + "\"";
@@ -277,7 +277,7 @@ public final class Out {
    * @param message the code of the error message
    * @see ErrorMessages
    */
-  public static void error(ErrorMessages.ErrorMessage message) {
+  public static void error(ErrorMessages message) {
     errors++;
     err(NL + "Error: " + ErrorMessages.get(message));
   }
@@ -289,7 +289,7 @@ public final class Out {
    * @param message the code of the error message
    * @see ErrorMessages
    */
-  public static void error(ErrorMessages.ErrorMessage message, String data) {
+  public static void error(ErrorMessages message, String data) {
     errors++;
     err(NL + "Error: " + ErrorMessages.get(message, data));
   }
@@ -300,7 +300,7 @@ public final class Out {
    * @param message the code of the error message
    * @param file the file it occurred for
    */
-  public static void error(ErrorMessages.ErrorMessage message, File file) {
+  public static void error(ErrorMessages message, File file) {
     errors++;
     err(NL + "Error: " + ErrorMessages.get(message) + " (" + file + ")");
   }
@@ -313,7 +313,7 @@ public final class Out {
    * @param line the line number of error position
    * @param column the column of error position
    */
-  public static void error(File file, ErrorMessages.ErrorMessage message, int line, int column) {
+  public static void error(File file, ErrorMessages message, int line, int column) {
 
     String msg = NL + "Error";
     if (file != null) msg += " in file \"" + file + "\"";

--- a/jflex/src/main/java/jflex/scanner/ScannerException.java
+++ b/jflex/src/main/java/jflex/scanner/ScannerException.java
@@ -21,11 +21,10 @@ public class ScannerException extends RuntimeException {
 
   public int line;
   public int column;
-  public ErrorMessages.ErrorMessage message;
+  public ErrorMessages message;
   public File file;
 
-  private ScannerException(
-      File file, String text, ErrorMessages.ErrorMessage message, int line, int column) {
+  private ScannerException(File file, String text, ErrorMessages message, int line, int column) {
     super(text);
     this.file = file;
     this.message = message;
@@ -38,7 +37,7 @@ public class ScannerException extends RuntimeException {
    *
    * @param message the code for the error description presented to the user.
    */
-  public ScannerException(ErrorMessages.ErrorMessage message) {
+  public ScannerException(ErrorMessages message) {
     this(null, ErrorMessages.get(message), message, -1, -1);
   }
 
@@ -48,7 +47,7 @@ public class ScannerException extends RuntimeException {
    * @param file the file in which the error occurred
    * @param message the code for the error description presented to the user.
    */
-  public ScannerException(File file, ErrorMessages.ErrorMessage message) {
+  public ScannerException(File file, ErrorMessages message) {
     this(file, ErrorMessages.get(message), message, -1, -1);
   }
 
@@ -58,7 +57,7 @@ public class ScannerException extends RuntimeException {
    * @param message the code for the error description presented to the user.
    * @param line the number of the line in the specification that contains the error
    */
-  public ScannerException(ErrorMessages.ErrorMessage message, int line) {
+  public ScannerException(ErrorMessages message, int line) {
     this(null, ErrorMessages.get(message), message, line, -1);
   }
 
@@ -69,7 +68,7 @@ public class ScannerException extends RuntimeException {
    * @param line the number of the line in the specification that contains the error
    * @param file a {@link java.io.File} object.
    */
-  public ScannerException(File file, ErrorMessages.ErrorMessage message, int line) {
+  public ScannerException(File file, ErrorMessages message, int line) {
     this(file, ErrorMessages.get(message), message, line, -1);
   }
 
@@ -81,7 +80,7 @@ public class ScannerException extends RuntimeException {
    * @param column the column where the error starts
    * @param file a {@link java.io.File} object.
    */
-  public ScannerException(File file, ErrorMessages.ErrorMessage message, int line, int column) {
+  public ScannerException(File file, ErrorMessages message, int line, int column) {
     this(file, ErrorMessages.get(message), message, line, column);
   }
 }


### PR DESCRIPTION
Shorter and less duplication. Our old Java hacks to get enums can finally be retired.