### PR TITLE
jflex PackEmitter: remove debugging code

### DIFF
--- a/jflex/src/main/java/jflex/generator/PackEmitter.java
+++ b/jflex/src/main/java/jflex/generator/PackEmitter.java
@@ -97,7 +97,6 @@ public abstract class PackEmitter {
    * @param i the character to emit.
    */
   public void emitUC(int i) {
-    if (i > 0xFFFF) i = 0xFFFF;
     if (i < 0 || i > 0xFFFF) {
       throw new IllegalArgumentException("character value expected, but got " + i);
     }


### PR DESCRIPTION
(was introduced for debugging only and can lead to unwanted behaviour)