### PR TITLE
github: filter CodeQL results

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -42,3 +42,18 @@ jobs:
         uses: github/codeql-action/analyze@v2
         with:
           category: "/language:${{ matrix.language }}"
+          upload: False
+          output: sarif-results
+
+      - name: Filter Scanning Results
+        uses: advanced-security/filter-sarif@v1
+        with:
+          patterns: |
+            -**/LexParse.java:java/unused-local-variable
+          input: sarif-results/java.sarif
+          output: sarif-results/java.sarif
+
+      - name: Upload Scanning Results
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: sarif-results/java.sarif


### PR DESCRIPTION
Filter out unused-local-variable warnings for LexParse.java. Cup generates lots of unused local variables that we're not intending to eliminate.