### PR TITLE
warn for unicode escapes that are too long

### DIFF
--- a/docs/md/installing.md
+++ b/docs/md/installing.md
@@ -155,11 +155,13 @@ doing)
 
 `--warn-<warning>`\
 switch on warning type `<warning>`, where `<warning>` is one of
-`unused`, `never-match`, `empty-match`, `cupsym-after-cup`, `all`.
+`unused`, `never-match`, `empty-match`, `cupsym-after-cup`, `unicode-too-long`,
+`all`.
 
 `--no-warn-<warning>`\
 suppress warnings of type `<warning>`, where `<warning>` is one of
-`unused`, `never-match`, `empty-match`, `cupsym-after-cup`, `all`.
+`unused`, `never-match`, `empty-match`, `cupsym-after-cup`, `unicode-too-long`,
+`all`.
 
 `--time`\
 display time statistics about the code generation process (not very

--- a/docs/md/lex-specs.md
+++ b/docs/md/lex-specs.md
@@ -494,6 +494,7 @@ interested in how to interface your generated scanner with Byacc/J.
 - `empty-match`: warn for rules that can match the empty string
 - `cupsym-after-cup`: warn for re-declaring the `cup` symbol even though `%cup`
   is present
+- `unicode-too-long`: warn for unicode escape sequences that have too many digits
 - `all`: switch on/off all warnings
 
 

--- a/javatests/de/jflex/testcase/six_digit_unicode_escape/failure2.out
+++ b/javatests/de/jflex/testcase/six_digit_unicode_escape/failure2.out
@@ -1,5 +1,10 @@
 Reading "javatests/de/jflex/testcase/six_digit_unicode_escape/SixDigitUnicodeEscape-f-2.flex"
 
+Warning in file "javatests/de/jflex/testcase/six_digit_unicode_escape/SixDigitUnicodeEscape-f-2.flex" (line 13): 
+Unicode escape sequence is too long. Use \u{...} to disambiguate.
+"one two three\UFFFFFFabc" { }
+                      ^
+
 Error in file "javatests/de/jflex/testcase/six_digit_unicode_escape/SixDigitUnicodeEscape-f-2.flex" (line 13): 
 Hexadecimal code point is greater than the maximum allowed code point
 "one two three\UFFFFFFabc" { }

--- a/javatests/de/jflex/testcase/unicode_escape_warning/BUILD.bazel
+++ b/javatests/de/jflex/testcase/unicode_escape_warning/BUILD.bazel
@@ -1,0 +1,40 @@
+# Copyright 2021, Régis Décamps
+# SPDX-License-Identifier: BSD-3-Clause
+
+load("//testsuite:testsuite.bzl", "jflex_testsuite")
+load("@jflex_rules//jflex:jflex.bzl", "jflex")
+load("//scripts:check_deps.bzl", "check_deps")
+
+check_deps(
+    name = "deps_to_bootstrap_jflex_test",
+    prohibited = "@jflex_rules//jflex:jflex_bin",
+)
+
+jflex(
+    name = "warnings_flex",
+    srcs = ["warnings.flex"],
+    jflex_bin = "//jflex:jflex_bin",
+    outputs = ["Warnings.java"],
+)
+
+java_library(
+    name = "warnings_scanner",
+    srcs = [
+        ":warnings_flex",
+    ],
+)
+
+jflex_testsuite(
+    name = "WarningsTest",
+    srcs = [
+        "WarningsTest.java",
+    ],
+    data = [
+        "sys-out.txt",
+        "warnings.flex",
+    ],
+    deps = [
+        ":warnings_scanner",
+        "//java/de/jflex/util/scanner:scanner_factory",
+    ],
+)

--- a/javatests/de/jflex/testcase/unicode_escape_warning/WarningsTest.java
+++ b/javatests/de/jflex/testcase/unicode_escape_warning/WarningsTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2023, Gerwin Klein <lsf@jflex.de>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+package de.jflex.testcase.unicode_escape_warning;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import de.jflex.testing.testsuite.JFlexTestRunner;
+import de.jflex.testing.testsuite.annotations.TestSpec;
+import de.jflex.util.scanner.ScannerFactory;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Test warnings for and matching for unicode espace sequences that are too long.
+ *
+ * <p>See also <a href="https://github.com/jflex-de/jflex/pull/183">#183</a>.
+ */
+@RunWith(JFlexTestRunner.class)
+@TestSpec(
+    lex = "javatests/de/jflex/testcase/unicode_escape_warning/warnings.flex",
+    sysout = "javatests/de/jflex/testcase/unicode_escape_warning/sys-out.txt",
+    quiet = true)
+public class WarningsTest {
+  private final ScannerFactory<Warnings> scannerFactory = ScannerFactory.of(Warnings::new);
+
+  @Test
+  public void run() throws java.io.IOException {
+    Warnings scanner = scannerFactory.createScannerWithContent("013245020210ab121201ab0");
+    assertThat(scanner.yylex()).isEqualTo(0);
+    assertThat(scanner.yylex()).isEqualTo(1);
+    assertThat(scanner.yylex()).isEqualTo(3);
+    assertThat(scanner.yylex()).isEqualTo(2);
+    assertThat(scanner.yylex()).isEqualTo(4);
+    assertThat(scanner.yylex()).isEqualTo(5);
+    assertThat(scanner.yylex()).isEqualTo(6);
+    assertThat(scanner.yylex()).isEqualTo(7);
+    assertThat(scanner.yylex()).isEqualTo(8);
+    assertThat(scanner.yylex()).isEqualTo(9);
+    assertThat(scanner.yylex()).isEqualTo(10);
+    assertThat(scanner.yylex()).isEqualTo(11);
+    assertThat(scanner.yylex()).isEqualTo(0);
+    assertThat(scanner.yylex()).isEqualTo(-1);
+  }
+}

--- a/javatests/de/jflex/testcase/unicode_escape_warning/sys-out.txt
+++ b/javatests/de/jflex/testcase/unicode_escape_warning/sys-out.txt
@@ -1,0 +1,30 @@
+
+Warning in file "javatests/de/jflex/testcase/unicode_escape_warning/warnings.flex" (line 28): 
+Unicode escape sequence is too long. Use \u{...} to disambiguate.
+\u00302       { return 6; }
+      ^
+
+Warning in file "javatests/de/jflex/testcase/unicode_escape_warning/warnings.flex" (line 29): 
+Unicode escape sequence is too long. Use \u{...} to disambiguate.
+\u003021      { return 7; }
+      ^
+
+Warning in file "javatests/de/jflex/testcase/unicode_escape_warning/warnings.flex" (line 30): 
+Unicode escape sequence is too long. Use \u{...} to disambiguate.
+\U000030ab    { return 8; }
+        ^
+
+Warning in file "javatests/de/jflex/testcase/unicode_escape_warning/warnings.flex" (line 32): 
+Unicode escape sequence is too long. Use \u{...} to disambiguate.
+"\u00312"     { return 9; }
+       ^
+
+Warning in file "javatests/de/jflex/testcase/unicode_escape_warning/warnings.flex" (line 33): 
+Unicode escape sequence is too long. Use \u{...} to disambiguate.
+"\u003120"    { return 10; }
+       ^
+
+Warning in file "javatests/de/jflex/testcase/unicode_escape_warning/warnings.flex" (line 34): 
+Unicode escape sequence is too long. Use \u{...} to disambiguate.
+"\U000031ab"  { return 11; }
+         ^

--- a/javatests/de/jflex/testcase/unicode_escape_warning/warnings.flex
+++ b/javatests/de/jflex/testcase/unicode_escape_warning/warnings.flex
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2023, Gerwin Klein <lsf@jflex.de>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+package de.jflex.testcase.unicode_escape_warning;
+
+%%
+
+%public
+%class Warnings
+%int
+
+// %unicode // default
+
+%%
+
+// no warnings
+\u0030        { return 0; }
+\U000031      { return 1; }
+\u{000032}    { return 2; }
+
+"\u0033"      { return 3; }
+"\U000034"    { return 4; }
+"\u{000035}"  { return 5; }
+
+// warning, and match extra characters
+\u00302       { return 6; }
+\u003021      { return 7; }
+\U000030ab    { return 8; }
+
+"\u00312"     { return 9; }
+"\u003120"    { return 10; }
+"\U000031ab"  { return 11; }

--- a/jflex/src/main/java/jflex/core/AbstractLexScan.java
+++ b/jflex/src/main/java/jflex/core/AbstractLexScan.java
@@ -15,6 +15,7 @@ import java.util.Set;
 import java_cup.runtime.Symbol;
 import jflex.core.unicode.CharClasses;
 import jflex.core.unicode.ILexScan;
+import jflex.core.unicode.IntCharSet;
 import jflex.core.unicode.UnicodeProperties;
 import jflex.l10n.ErrorMessages;
 import jflex.logging.Out;
@@ -88,6 +89,20 @@ public abstract class AbstractLexScan implements ILexScan {
   @Override
   public UnicodeProperties getUnicodeProperties() {
     return unicodeProperties;
+  }
+
+  public int getMaximumCodePoint() {
+    if (unicodeProperties == null) {
+      populateDefaultVersionUnicodeProperties();
+    }
+    return unicodeProperties.getMaximumCodePoint();
+  }
+
+  public IntCharSet getIntCharSet(String propertyValue) {
+    if (unicodeProperties == null) {
+      populateDefaultVersionUnicodeProperties();
+    }
+    return unicodeProperties.getIntCharSet(propertyValue);
   }
 
   @SuppressWarnings("unused") // Used in generated LexParse

--- a/jflex/src/main/java/jflex/core/AbstractLexScan.java
+++ b/jflex/src/main/java/jflex/core/AbstractLexScan.java
@@ -419,6 +419,21 @@ public abstract class AbstractLexScan implements ILexScan {
     return columnCount;
   }
 
+  /**
+   * Warn if the matched length of a Unicode escape sequence is longer than expected. Push back the
+   * extra characters to be matched again.
+   *
+   * @param len expected Unicode escape sequence length
+   */
+  public void maybeWarnUnicodeMatch(int len) {
+    // 2 for "\"" followed by "u" or "U" at start of match
+    len += 2;
+    if (lexLength() > len) {
+      Out.warning(file, ErrorMessages.UNICODE_TOO_LONG, lexLine(), lexColumn() + len);
+      lexPushback(lexLength() - len);
+    }
+  }
+
   @SuppressWarnings("WeakerAccess") // Implemented by generated LexScan
   protected abstract int lexLine();
 
@@ -426,7 +441,13 @@ public abstract class AbstractLexScan implements ILexScan {
   protected abstract int lexColumn();
 
   @SuppressWarnings("WeakerAccess") // Implemented by generated LexScan
+  protected abstract int lexLength();
+
+  @SuppressWarnings("WeakerAccess") // Implemented by generated LexScan
   protected abstract String lexText();
+
+  @SuppressWarnings("WeakerAccess") // Implemented by generated LexScan
+  protected abstract void lexPushback(int n);
 
   @SuppressWarnings("WeakerAccess") // Implemented by generated LexScan
   protected abstract void lexPushStream(File f) throws IOException;

--- a/jflex/src/main/java/jflex/l10n/ErrorMessages.java
+++ b/jflex/src/main/java/jflex/l10n/ErrorMessages.java
@@ -105,12 +105,19 @@ public enum ErrorMessages {
   NOT_CHARCLASS,
   MACRO_UNUSED,
   UNKNOWN_WARNING,
-  NOT_A_WARNING_ID;
+  NOT_A_WARNING_ID,
+  UNICODE_TOO_LONG;
 
   private static final Set<ErrorMessages> configurableWarnings =
       new HashSet<>(
           Arrays.asList(
-              NEVER_MATCH, EMPTY_MATCH, CTOR_DEBUG, NOT_AT_BOL, MACRO_UNUSED, CUPSYM_AFTER_CUP));
+              NEVER_MATCH,
+              EMPTY_MATCH,
+              CTOR_DEBUG,
+              NOT_AT_BOL,
+              MACRO_UNUSED,
+              CUPSYM_AFTER_CUP,
+              UNICODE_TOO_LONG));
 
   /* not final static, because initializing here seems too early
    * for OS/2 JDK 1.1.8. See bug 1065521.

--- a/jflex/src/main/jflex/LexScan.flex
+++ b/jflex/src/main/jflex/LexScan.flex
@@ -427,7 +427,7 @@ DottedVersion =  [1-9][0-9]*(\.[0-9]+){0,2}
     {WSPNL}*"\\W"              { return symbol(sym.WORDCLASSNOT); }
     {WSPNL}*"\\p{"[^}]*"}"     { String trimmedText = yytext().trim();
                                  String propertyValue = trimmedText.substring(3,trimmedText.length()-1);
-                                 IntCharSet set = unicodeProperties.getIntCharSet(propertyValue);
+                                 IntCharSet set = getIntCharSet(propertyValue);
                                  if (null == set) {
                                    throw new ScannerException(file,ErrorMessages.INVALID_UNICODE_PROPERTY, yyline, yycolumn + 3);
                                  }
@@ -435,7 +435,7 @@ DottedVersion =  [1-9][0-9]*(\.[0-9]+){0,2}
                                }
     {WSPNL}*"\\P{"[^}]*"}"     { String trimmedText = yytext().trim();
                                  String propertyValue = trimmedText.substring(3,trimmedText.length()-1);
-                                 IntCharSet set = unicodeProperties.getIntCharSet(propertyValue);
+                                 IntCharSet set = getIntCharSet(propertyValue);
                                  if (null == set) {
                                    throw new ScannerException(file,ErrorMessages.INVALID_UNICODE_PROPERTY, yyline, yycolumn + 3);
                                  }
@@ -496,7 +496,7 @@ DottedVersion =  [1-9][0-9]*(\.[0-9]+){0,2}
               }
   {Unicode6}  { maybeWarnUnicodeMatch(6);
                 int codePoint = Integer.parseInt(yytext().substring(2,8), 16);
-                if (codePoint <= unicodeProperties.getMaximumCodePoint()) {
+                if (codePoint <= getMaximumCodePoint()) {
                   string.append(Character.toChars(codePoint));
                 } else {
                   throw new ScannerException(file,ErrorMessages.CODEPOINT_OUT_OF_RANGE, yyline, yycolumn+2);
@@ -525,7 +525,7 @@ DottedVersion =  [1-9][0-9]*(\.[0-9]+){0,2}
               }
   {Unicode6}  { maybeWarnUnicodeMatch(6);
                 int codePoint = Integer.parseInt(yytext().substring(2,8), 16);
-                if (codePoint <= unicodeProperties.getMaximumCodePoint()) {
+                if (codePoint <= getMaximumCodePoint()) {
                   return symbol(sym.CHAR, codePoint);
                 } else {
                   throw new ScannerException(file,ErrorMessages.CODEPOINT_OUT_OF_RANGE, yyline, yycolumn+2);
@@ -578,7 +578,7 @@ DottedVersion =  [1-9][0-9]*(\.[0-9]+){0,2}
 <REGEXP_CODEPOINT_SEQUENCE> {
   "}"             { yybegin(REGEXP); return symbol(sym.STRING, string.toString()); }
   {HexDigit}{1,6} { int codePoint = Integer.parseInt(yytext(), 16);
-                    if (codePoint <= unicodeProperties.getMaximumCodePoint()) {
+                    if (codePoint <= getMaximumCodePoint()) {
                       string.append(Character.toChars(codePoint));
                     } else {
                       throw new ScannerException(file,ErrorMessages.CODEPOINT_OUT_OF_RANGE, yyline, yycolumn);
@@ -591,7 +591,7 @@ DottedVersion =  [1-9][0-9]*(\.[0-9]+){0,2}
 <STRING_CODEPOINT_SEQUENCE> { // Specialized form: newlines disallowed, and doesn't return a symbol
   "}"             { yybegin(STRING_CONTENT); }
   {HexDigit}{1,6} { int codePoint = Integer.parseInt(yytext(), 16);
-                    if (codePoint <= unicodeProperties.getMaximumCodePoint()) {
+                    if (codePoint <= getMaximumCodePoint()) {
                       string.append(Character.toChars(codePoint));
                     } else {
                       throw new ScannerException(file, ErrorMessages.CODEPOINT_OUT_OF_RANGE, yyline, yycolumn);
@@ -604,7 +604,7 @@ DottedVersion =  [1-9][0-9]*(\.[0-9]+){0,2}
 
 <CHARCLASS_CODEPOINT> { // Specialized form: only one codepoint allowed, no whitespace allowed
   {HexDigit}{1,6} "}" { int codePoint = Integer.parseInt(yytext().substring(0, yylength() - 1), 16);
-                        if (codePoint <= unicodeProperties.getMaximumCodePoint()) {
+                        if (codePoint <= getMaximumCodePoint()) {
                           yybegin(CHARCLASS);
                           return symbol(sym.CHAR, codePoint);
                         } else {

--- a/jflex/src/main/resources/jflex/Messages.properties
+++ b/jflex/src/main/resources/jflex/Messages.properties
@@ -87,3 +87,4 @@ NOT_CHARCLASS = Expression inside [..] must expand to a character class.
 MACRO_UNUSED = Macro "{0}" has been declared but never used.
 UNKNOWN_WARNING = Warning type "{0}" unknown or not configurable.
 NOT_A_WARNING_ID = Warning type unknown.
+UNICODE_TOO_LONG = Unicode escape sequence is too long. Use \\u{...} to disambiguate.


### PR DESCRIPTION
`\u` with more than 4 or `\U` with more than 6 hex digits previously were silently split into the legal 4 or 6 unicode escape, followed by normal character matches. Usually these occurrences are errors, but there may be specifications that rely on this behaviour, so instead of an error we produce a warning that can be suppressed.

Fixes #183