### PR TITLE
implement optional limit on token size 

### DIFF
--- a/docs/md/lex-specs.md
+++ b/docs/md/lex-specs.md
@@ -160,7 +160,28 @@ generated scanner class.
 -   `%buffer "size"`
 
     Set the initial size of the scan buffer to the specified value
-    (decimal, in bytes). The default value is 16384.
+    (decimal, in bytes). The default value is 16384. The buffer will
+    be set to the minimum of `%token_size_limit` (if provided) and
+    `%buffer` size.
+
+-   `%token_size_limit "size"`
+
+    Set the maximum size of the scan buffer to the specified size provided
+    as a Java numeral (decimal, octal, or hex) or as a qualified identifier.
+    If provided as identifier, the identifier can refer to a static constant or
+    a field which can be modified at runtime in user class code.
+    Setting `%token_size_limit ZZ_BUFFERSIZE` will limit the scan buffer to its
+    initial size.
+
+    Limiting the token size introduces an error case: when the scanner
+    encounters a token that does not fit into the maximum buffer size, it will
+    throw a `java.io.EOFException`. Tokens smaller than the maximum buffer
+    size are guaranteed to match. Not that the longest-match rule applies, that
+    is `a*` will lead to an `EOFException` on input that contains a too-long
+    `a` sequence, even if the smaller match could be possible.
+
+    The limit is inteded to be used for applications that require a memory
+    limit on parsing untrusted input.
 
 -   `%include "filename"`
 

--- a/javatests/de/jflex/testcase/ccl_bug/CclBugTest.java
+++ b/javatests/de/jflex/testcase/ccl_bug/CclBugTest.java
@@ -10,7 +10,7 @@ import de.jflex.util.scanner.ScannerFactory;
 import org.junit.Test;
 
 /**
- * Test against <a href="https://github.com/jflex-de/jflex/issues/81>#81 {@code char[] ZZ_CMAP} is
+ * Test against <a href="https://github.com/jflex-de/jflex/issues/81">#81 {@code char[] ZZ_CMAP} is
  * incorrect</a>
  *
  * <p>Generated CclBug.java does not compile, because of missing ",".

--- a/javatests/de/jflex/testcase/token_limit/BUILD.bazel
+++ b/javatests/de/jflex/testcase/token_limit/BUILD.bazel
@@ -1,0 +1,54 @@
+# Copyright 2023, Gerwin Klein <lsf@jflex.de>
+# SPDX-License-Identifier: BSD-3-Clause
+
+load("//testsuite:testsuite.bzl", "jflex_testsuite")
+load("@jflex_rules//jflex:jflex.bzl", "jflex")
+load("//scripts:check_deps.bzl", "check_deps")
+
+check_deps(
+    name = "deps_to_bootstrap_jflex_test",
+    prohibited = "@jflex_rules//jflex:jflex_bin",
+)
+
+[jflex_testsuite(
+    name = "LimitTest%d" % i,
+    srcs = [
+        "LimitTest%d.java" % i,
+    ],
+    data = [
+        "sys-out%d.txt" % i,
+        "limit%d.flex" % i,
+    ],
+    deps = [
+        "//jflex/src/main/java/jflex/exceptions",
+    ],
+) for i in range(1, 6)]
+
+jflex(
+    name = "gen_limit_scanner",
+    srcs = ["limit_success.flex"],
+    jflex_bin = "//jflex:jflex_bin",
+    outputs = ["Limit_Success.java"],
+)
+
+java_library(
+    name = "limit_scanner",
+    srcs = [
+        ":gen_limit_scanner",
+    ],
+)
+
+java_test(
+    name = "LimitTest0",
+    size = "small",
+    srcs = [
+        "LimitTest0.java",
+    ],
+    data = [
+    ],
+    deps = [
+        ":limit_scanner",
+        "//java/de/jflex/util/scanner:scanner_factory",
+        "//third_party/com/google/truth",
+    ],
+)

--- a/javatests/de/jflex/testcase/token_limit/LimitTest0.java
+++ b/javatests/de/jflex/testcase/token_limit/LimitTest0.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2023, Gerwin Klein <lsf@jflex.de>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+package de.jflex.testcase.token_limit;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import de.jflex.util.scanner.ScannerFactory;
+import java.io.EOFException;
+import org.junit.Test;
+
+/**
+ * Test success cases for {@code %token_size_limit} directive.
+ *
+ * <p>See also <a href="https://github.com/jflex-de/jflex/issues/197">#197</a>.
+ */
+public class LimitTest0 {
+  private final ScannerFactory<Limit_Success> scannerFactory =
+      ScannerFactory.of(Limit_Success::new);
+
+  @Test
+  public void only_long_token() throws Exception {
+    Limit_Success scanner = scannerFactory.createScannerWithContent("aaaaaaaa");
+    assertThat(scanner.yylex()).isEqualTo(0);
+    assertThat(scanner.yylex()).isEqualTo(-1);
+  }
+
+  @Test
+  public void two_long_tokens() throws Exception {
+    Limit_Success scanner = scannerFactory.createScannerWithContent("aaaaaaaaaaaaaaaa");
+    assertThat(scanner.yylex()).isEqualTo(0);
+    assertThat(scanner.yylex()).isEqualTo(0);
+    assertThat(scanner.yylex()).isEqualTo(-1);
+  }
+
+  @Test
+  public void two_long_tokens_separated() throws Exception {
+    Limit_Success scanner = scannerFactory.createScannerWithContent("baaaaaaaabbaaaaaaaa");
+    assertThat(scanner.yylex()).isEqualTo(1);
+    assertThat(scanner.yylex()).isEqualTo(0);
+    assertThat(scanner.yylex()).isEqualTo(1);
+    assertThat(scanner.yylex()).isEqualTo(1);
+    assertThat(scanner.yylex()).isEqualTo(0);
+    assertThat(scanner.yylex()).isEqualTo(-1);
+  }
+
+  @Test
+  public void too_long() throws Exception {
+    Limit_Success scanner = scannerFactory.createScannerWithContent("cccccccccc");
+    try {
+      scanner.yylex();
+      assertThat(false).isTrue();
+    } catch (EOFException e) {
+      assertThat(e.getMessage()).isEqualTo("Scan buffer limit reached [8]");
+    }
+  }
+
+  @Test
+  public void too_long_later() throws Exception {
+    Limit_Success scanner = scannerFactory.createScannerWithContent("aaaaaaaabbcccccccccc");
+    assertThat(scanner.yylex()).isEqualTo(0);
+    assertThat(scanner.yylex()).isEqualTo(1);
+    assertThat(scanner.yylex()).isEqualTo(1);
+    try {
+      assertThat(scanner.yylex()).isEqualTo(3);
+      assertThat(false).isTrue();
+    } catch (EOFException e) {
+      assertThat(e.getMessage()).isEqualTo("Scan buffer limit reached [8]");
+    }
+  }
+}

--- a/javatests/de/jflex/testcase/token_limit/LimitTest1.java
+++ b/javatests/de/jflex/testcase/token_limit/LimitTest1.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2023, Gerwin Klein <lsf@jflex.de>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+package de.jflex.testcase.token_limit;
+
+import de.jflex.testing.testsuite.JFlexTestRunner;
+import de.jflex.testing.testsuite.annotations.TestSpec;
+import jflex.exceptions.GeneratorException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Test errors for {@code %token_size_limit} directive.
+ *
+ * <p>See also <a href="https://github.com/jflex-de/jflex/issues/197">#197</a>.
+ */
+@RunWith(JFlexTestRunner.class)
+@TestSpec(
+    lex = "javatests/de/jflex/testcase/token_limit/limit1.flex",
+    sysout = "javatests/de/jflex/testcase/token_limit/sys-out1.txt",
+    quiet = true,
+    generatorThrows = GeneratorException.class)
+public class LimitTest1 {
+  @Test
+  public void ok() {}
+}

--- a/javatests/de/jflex/testcase/token_limit/LimitTest2.java
+++ b/javatests/de/jflex/testcase/token_limit/LimitTest2.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2023, Gerwin Klein <lsf@jflex.de>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+package de.jflex.testcase.token_limit;
+
+import de.jflex.testing.testsuite.JFlexTestRunner;
+import de.jflex.testing.testsuite.annotations.TestSpec;
+import jflex.exceptions.GeneratorException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Test errors for {@code %token_size_limit} directive.
+ *
+ * <p>See also <a href="https://github.com/jflex-de/jflex/issues/197">#197</a>.
+ */
+@RunWith(JFlexTestRunner.class)
+@TestSpec(
+    lex = "javatests/de/jflex/testcase/token_limit/limit2.flex",
+    sysout = "javatests/de/jflex/testcase/token_limit/sys-out2.txt",
+    quiet = true,
+    generatorThrows = GeneratorException.class)
+public class LimitTest2 {
+  @Test
+  public void ok() {}
+}

--- a/javatests/de/jflex/testcase/token_limit/LimitTest3.java
+++ b/javatests/de/jflex/testcase/token_limit/LimitTest3.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2023, Gerwin Klein <lsf@jflex.de>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+package de.jflex.testcase.token_limit;
+
+import de.jflex.testing.testsuite.JFlexTestRunner;
+import de.jflex.testing.testsuite.annotations.TestSpec;
+import jflex.exceptions.GeneratorException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Test errors for {@code %token_size_limit} directive.
+ *
+ * <p>See also <a href="https://github.com/jflex-de/jflex/issues/197">#197</a>.
+ */
+@RunWith(JFlexTestRunner.class)
+@TestSpec(
+    lex = "javatests/de/jflex/testcase/token_limit/limit3.flex",
+    sysout = "javatests/de/jflex/testcase/token_limit/sys-out3.txt",
+    quiet = true,
+    generatorThrows = GeneratorException.class)
+public class LimitTest3 {
+  @Test
+  public void ok() {}
+}

--- a/javatests/de/jflex/testcase/token_limit/LimitTest4.java
+++ b/javatests/de/jflex/testcase/token_limit/LimitTest4.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2023, Gerwin Klein <lsf@jflex.de>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+package de.jflex.testcase.token_limit;
+
+import de.jflex.testing.testsuite.JFlexTestRunner;
+import de.jflex.testing.testsuite.annotations.TestSpec;
+import jflex.exceptions.GeneratorException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Test errors for {@code %token_size_limit} directive.
+ *
+ * <p>See also <a href="https://github.com/jflex-de/jflex/issues/197">#197</a>.
+ */
+@RunWith(JFlexTestRunner.class)
+@TestSpec(
+    lex = "javatests/de/jflex/testcase/token_limit/limit4.flex",
+    sysout = "javatests/de/jflex/testcase/token_limit/sys-out4.txt",
+    quiet = true,
+    generatorThrows = GeneratorException.class)
+public class LimitTest4 {
+  @Test
+  public void ok() {}
+}

--- a/javatests/de/jflex/testcase/token_limit/LimitTest5.java
+++ b/javatests/de/jflex/testcase/token_limit/LimitTest5.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2023, Gerwin Klein <lsf@jflex.de>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+package de.jflex.testcase.token_limit;
+
+import de.jflex.testing.testsuite.JFlexTestRunner;
+import de.jflex.testing.testsuite.annotations.TestSpec;
+import jflex.exceptions.GeneratorException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Test errors for {@code %token_size_limit} directive.
+ *
+ * <p>See also <a href="https://github.com/jflex-de/jflex/issues/197">#197</a>.
+ */
+@RunWith(JFlexTestRunner.class)
+@TestSpec(
+    lex = "javatests/de/jflex/testcase/token_limit/limit5.flex",
+    sysout = "javatests/de/jflex/testcase/token_limit/sys-out5.txt",
+    quiet = true,
+    generatorThrows = GeneratorException.class)
+public class LimitTest5 {
+  @Test
+  public void ok() {}
+}

--- a/javatests/de/jflex/testcase/token_limit/limit1.flex
+++ b/javatests/de/jflex/testcase/token_limit/limit1.flex
@@ -1,0 +1,11 @@
+/*
+ * Copyright 2023, Gerwin Klein <lsf@jflex.de>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+%%
+
+// should error -- missing parameter
+%token_size_limit
+
+%%

--- a/javatests/de/jflex/testcase/token_limit/limit2.flex
+++ b/javatests/de/jflex/testcase/token_limit/limit2.flex
@@ -1,0 +1,11 @@
+/*
+ * Copyright 2023, Gerwin Klein <lsf@jflex.de>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+%%
+
+// should error -- illegal oct literal
+%token_size_limit 099
+
+%%

--- a/javatests/de/jflex/testcase/token_limit/limit3.flex
+++ b/javatests/de/jflex/testcase/token_limit/limit3.flex
@@ -1,0 +1,11 @@
+/*
+ * Copyright 2023, Gerwin Klein <lsf@jflex.de>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+%%
+
+// should error -- illegal hex literal
+%token_size_limit 0xABCDEFG
+
+%%

--- a/javatests/de/jflex/testcase/token_limit/limit4.flex
+++ b/javatests/de/jflex/testcase/token_limit/limit4.flex
@@ -1,0 +1,11 @@
+/*
+ * Copyright 2023, Gerwin Klein <lsf@jflex.de>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+%%
+
+// should error -- (unfortunately) illegal dec literal
+%token_size_limit 100_000
+
+%%

--- a/javatests/de/jflex/testcase/token_limit/limit5.flex
+++ b/javatests/de/jflex/testcase/token_limit/limit5.flex
@@ -1,0 +1,11 @@
+/*
+ * Copyright 2023, Gerwin Klein <lsf@jflex.de>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+%%
+
+// should error -- illegal ident
+%token_size_limit %not_an_identifier
+
+%%

--- a/javatests/de/jflex/testcase/token_limit/limit_success.flex
+++ b/javatests/de/jflex/testcase/token_limit/limit_success.flex
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2023, Gerwin Klein <lsf@jflex.de>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+package de.jflex.testcase.token_limit;
+
+%%
+
+%public
+%class Limit_Success
+%int
+
+// size 8 (oct literal)
+%token_size_limit 010
+
+%%
+
+// longest token that can be matched; should be matched even if buffer is not empty
+"a"{8}       { return 0; }
+
+// something to fill the buffer with
+"b"          { return 1; }
+
+// should result in EOFException when encountered in inptu
+"c"{8} "c"+  { return 2; }
+
+// fallback
+[^]          { return 3; }

--- a/javatests/de/jflex/testcase/token_limit/sys-out1.txt
+++ b/javatests/de/jflex/testcase/token_limit/sys-out1.txt
@@ -1,0 +1,4 @@
+
+Error in file "javatests/de/jflex/testcase/token_limit/limit1.flex" (line 9): 
+Token size limit expected (number literal or qualified identifier).
+%token_size_limit

--- a/javatests/de/jflex/testcase/token_limit/sys-out2.txt
+++ b/javatests/de/jflex/testcase/token_limit/sys-out2.txt
@@ -1,0 +1,4 @@
+
+Error in file "javatests/de/jflex/testcase/token_limit/limit2.flex" (line 9): 
+Token size limit expected (number literal or qualified identifier).
+%token_size_limit 099

--- a/javatests/de/jflex/testcase/token_limit/sys-out3.txt
+++ b/javatests/de/jflex/testcase/token_limit/sys-out3.txt
@@ -1,0 +1,4 @@
+
+Error in file "javatests/de/jflex/testcase/token_limit/limit3.flex" (line 9): 
+Token size limit expected (number literal or qualified identifier).
+%token_size_limit 0xABCDEFG

--- a/javatests/de/jflex/testcase/token_limit/sys-out4.txt
+++ b/javatests/de/jflex/testcase/token_limit/sys-out4.txt
@@ -1,0 +1,4 @@
+
+Error in file "javatests/de/jflex/testcase/token_limit/limit4.flex" (line 9): 
+Token size limit expected (number literal or qualified identifier).
+%token_size_limit 100_000

--- a/javatests/de/jflex/testcase/token_limit/sys-out5.txt
+++ b/javatests/de/jflex/testcase/token_limit/sys-out5.txt
@@ -1,0 +1,4 @@
+
+Error in file "javatests/de/jflex/testcase/token_limit/limit5.flex" (line 9): 
+Token size limit expected (number literal or qualified identifier).
+%token_size_limit %not_an_identifier

--- a/jflex/lib/jflex-mode.el
+++ b/jflex/lib/jflex-mode.el
@@ -101,6 +101,7 @@
      "^%no-warn"
      "^%suppress"
      "^%no_suppress_warnings"
+     "^%token_size_limit"
      ("%[%{}0-9a-zA-Z]+" . font-lock-warning-face) ; errors
      ("{[ \t]*[a-zA-Z][0-9a-zA-Z_]+[ \t]*}" . font-lock-variable-name-face) ; macro uses
      "<<EOF>>" ; special <<EOF>> symbol

--- a/jflex/lib/jflex.vim
+++ b/jflex/lib/jflex.vim
@@ -82,6 +82,7 @@ syn match jflexOption "^%warn" contained
 syn match jflexOption "^%no-warn" contained
 syn match jflexOption "^%suppress" contained
 syn match jflexOption "^%no_suppress_warnings" contained
+syn match jflexOption "^%token_size_limit" contained
 
 syn match jflexMacroIdent "\I\i*\s*="me=e-1 contained nextgroup=jflexMacroRegExp
 

--- a/jflex/src/main/java/jflex/core/AbstractLexScan.java
+++ b/jflex/src/main/java/jflex/core/AbstractLexScan.java
@@ -76,6 +76,7 @@ public abstract class AbstractLexScan implements ILexScan {
   String functionName;
   String tokenType;
   String visibility = "public";
+  String tokenSizeLimit;
 
   List<String> ctorArgs = new ArrayList<>();
   List<String> ctorTypes = new ArrayList<>();
@@ -413,6 +414,10 @@ public abstract class AbstractLexScan implements ILexScan {
 
   public boolean noSuppressWarnings() {
     return noSuppressWarnings;
+  }
+
+  public String getTokenSizeLimit() {
+    return tokenSizeLimit;
   }
 
   /**

--- a/jflex/src/main/java/jflex/generator/Emitter.java
+++ b/jflex/src/main/java/jflex/generator/Emitter.java
@@ -175,7 +175,8 @@ public final class Emitter {
     if (!hasGenLookAhead()) return;
 
     println("  /** For the backwards DFA of general lookahead statements */");
-    println("  private boolean [] zzFin = new boolean [ZZ_BUFFERSIZE+1];");
+    println(
+        "  private boolean [] zzFin = new boolean [Math.min(ZZ_BUFFERSIZE, zzMaxBufferLen())+1];");
     println();
   }
 
@@ -1057,6 +1058,35 @@ public final class Emitter {
     println(e.toString());
   }
 
+  private void emitTokenSizeLimit(String limit) {
+    println();
+    println(
+        "  /** Returns the maximum size of the scanner buffer, which limits the size of tokens."
+            + " */");
+    println("  private int zzMaxBufferLen() {");
+    if (limit == null) {
+      println("    return Integer.MAX_VALUE;");
+    } else {
+      println("    return " + limit + ";");
+    }
+    println("  }");
+    println();
+    println("  /**");
+    println("   * Determine whether the scanner buffer can grow to accommodate a larger token.");
+    println("   *");
+    println("   * @param len the current length of the buffer.");
+    println("   * @return true iff the scanner buffer can grow further.");
+    println("   */");
+    println("  private boolean zzCanGrow(int len) {");
+    if (limit == null) {
+      println("    return true;");
+    } else {
+      println("    return len < zzMaxBufferLen();");
+    }
+    println("  }");
+    println();
+  }
+
   private void emitActions() {
     println("        switch (zzAction < 0 ? zzAction : ZZ_ACTION[zzAction]) {");
 
@@ -1401,6 +1431,8 @@ public final class Emitter {
       println("    return builder.toString();");
       println("  }");
     }
+
+    emitTokenSizeLimit(scanner.getTokenSizeLimit());
 
     emitCMapAccess();
 

--- a/jflex/src/main/java/jflex/l10n/ErrorMessages.java
+++ b/jflex/src/main/java/jflex/l10n/ErrorMessages.java
@@ -106,7 +106,8 @@ public enum ErrorMessages {
   MACRO_UNUSED,
   UNKNOWN_WARNING,
   NOT_A_WARNING_ID,
-  UNICODE_TOO_LONG;
+  UNICODE_TOO_LONG,
+  TOKEN_SIZE_LIMIT;
 
   private static final Set<ErrorMessages> configurableWarnings =
       new HashSet<>(

--- a/jflex/src/main/jflex/LexScan.flex
+++ b/jflex/src/main/jflex/LexScan.flex
@@ -90,6 +90,18 @@ import jflex.skeleton.Skeleton;
     // yypushStream in skeleton.nested
     yypushStream(Files.newBufferedReader(f.toPath(), Options.encoding));
   }
+
+  // Interface for the new skeleton that expects zzCanGrow() and zzMaxBufferLen()
+  // These will be inserted by JFlex >= 1.9.0, but we are generating with JFlex 1.8.2
+  // TODO(lsf): remove this method when JFlex 1.9.0 is released
+  private boolean zzCanGrow(int len) {
+    return true;
+  }
+
+  // TODO(lsf): remove this method when JFlex 1.9.0 is released
+  private int zzMaxBufferLen() {
+    return Integer.MAX_VALUE;
+  }
 %}
 
 %init{

--- a/jflex/src/main/jflex/LexScan.flex
+++ b/jflex/src/main/jflex/LexScan.flex
@@ -315,7 +315,7 @@ DottedVersion =  [1-9][0-9]*(\.[0-9]+){0,2}
   "%token_size_limit" {WSP}+ ({NumLiteral} | {QualIdent}) {WSP}* {
                                 tokenSizeLimit = yytext().substring(18).trim();
                               }
-  "%token_size_limit" {WSP}+ {NNL}* {
+  "%token_size_limit" {WSP}* {NNL}* {
                                  throw new ScannerException(file, ErrorMessages.TOKEN_SIZE_LIMIT, yyline);
                               }
 

--- a/jflex/src/main/jflex/LexScan.flex
+++ b/jflex/src/main/jflex/LexScan.flex
@@ -117,7 +117,8 @@ Number     = {Digit}+
 HexNumber  = \\ x {HexDigit} {2}
 OctNumber  = \\ [0-3]? {OctDigit} {1, 2}
 
-NumLiteral = {Number} | "0x" {HexDigit}+ | "0" {OctDigit}+
+// we want 099 to be an error, because it is an invalid octal literal
+NumLiteral = [1-9]{Digit}* | "0x" {HexDigit}+ | "0" {OctDigit}+
 
 // Unicode4 can encode chars only in the BMP with the 16 bits provided by its
 // 4 hex digits.

--- a/jflex/src/main/jflex/LexScan.flex
+++ b/jflex/src/main/jflex/LexScan.flex
@@ -105,6 +105,8 @@ Number     = {Digit}+
 HexNumber  = \\ x {HexDigit} {2}
 OctNumber  = \\ [0-3]? {OctDigit} {1, 2}
 
+NumLiteral = {Number} | "0x" {HexDigit}+ | "0" {OctDigit}+
+
 // Unicode4 can encode chars only in the BMP with the 16 bits provided by its
 // 4 hex digits.
 // Match and warn for Unicode escapes with too many digits -- it's legal syntax,
@@ -296,6 +298,13 @@ DottedVersion =  [1-9][0-9]*(\.[0-9]+){0,2}
   "%warn" {WSP}+ {NNL}* { throw new ScannerException(file, ErrorMessages.NOT_A_WARNING_ID, yyline); }
 
   "%no_suppress_warnings" {WSP}* { noSuppressWarnings = true; }
+
+  "%token_size_limit" {WSP}+ ({NumLiteral} | {QualIdent}) {WSP}* {
+                                tokenSizeLimit = yytext().substring(18).trim();
+                              }
+  "%token_size_limit" {WSP}+ {NNL}* {
+                                 throw new ScannerException(file, ErrorMessages.TOKEN_SIZE_LIMIT, yyline);
+                              }
 
   {Ident}                     { return symbol(sym.IDENT, yytext()); }
   "="{WSP}*                   { yybegin(REGEXP);

--- a/jflex/src/main/jflex/skeleton.nested
+++ b/jflex/src/main/jflex/skeleton.nested
@@ -32,7 +32,7 @@
 
   /** this buffer contains the current text to be matched and is
       the source of the yytext() string */
-  private char zzBuffer[] = new char[ZZ_BUFFERSIZE];
+  private char zzBuffer[] = new char[Math.min(ZZ_BUFFERSIZE, zzMaxBufferLen())];
 
   /** the textposition at the last accepting state */
   private int zzMarkedPos;
@@ -136,9 +136,9 @@
     }
 
     /* is the buffer big enough? */
-    if (zzCurrentPos >= zzBuffer.length - zzFinalHighSurrogate) {
+    if (zzCanGrow(zzBuffer.length) && zzCurrentPos >= zzBuffer.length - zzFinalHighSurrogate) {
       /* if not: blow it up */
-      char newBuffer[] = new char[zzBuffer.length * 2];
+      char newBuffer[] = new char[Math.min(zzBuffer.length * 2, zzMaxBufferLen())];
       System.arraycopy(zzBuffer, 0, newBuffer, 0, zzBuffer.length);
       zzBuffer = newBuffer;
       zzEndRead += zzFinalHighSurrogate;
@@ -151,7 +151,13 @@
 
     /* not supposed to occur according to specification of java.io.Reader */
     if (numRead == 0) {
-      throw new java.io.IOException("Reader returned 0 characters. See JFlex examples for workaround.");
+      if (requested == 0) {
+        throw new java.io.EOFException("Scan buffer limit reached ["+zzBuffer.length+"]");
+      }
+      else {
+        throw new java.io.IOException(
+            "Reader returned 0 characters. See JFlex examples/zero-reader for a workaround.");
+      }
     }
     if (numRead > 0) {
       zzEndRead += numRead;
@@ -208,7 +214,7 @@
                         zzMarkedPos, zzBuffer, zzAtBOL, zzAtEOF, zzEOFDone,
                         zzFinalHighSurrogate, yyline, yychar, yycolumn)
     );
-    zzBuffer = new char[ZZ_BUFFERSIZE];
+    zzBuffer = new char[Math.min(ZZ_BUFFERSIZE, zzMaxBufferLen())];
     zzReader = reader;
     yyResetPosition();
   }
@@ -274,8 +280,9 @@
     zzEOFDone = false;
     yyResetPosition();
     zzLexicalState = YYINITIAL;
-    if (zzBuffer.length > ZZ_BUFFERSIZE) {
-      zzBuffer = new char[ZZ_BUFFERSIZE];
+    int initBufferSize = Math.min(ZZ_BUFFERSIZE, zzMaxBufferLen());
+    if (zzBuffer.length > initBufferSize) {
+      zzBuffer = new char[initBufferSize];
     }
   }
 

--- a/jflex/src/main/resources/jflex/Messages.properties
+++ b/jflex/src/main/resources/jflex/Messages.properties
@@ -88,3 +88,4 @@ MACRO_UNUSED = Macro "{0}" has been declared but never used.
 UNKNOWN_WARNING = Warning type "{0}" unknown or not configurable.
 NOT_A_WARNING_ID = Warning type unknown.
 UNICODE_TOO_LONG = Unicode escape sequence is too long. Use \\u{...} to disambiguate.
+TOKEN_SIZE_LIMIT = Token size limit expected (number literal or qualified identifier).

--- a/jflex/src/main/resources/jflex/skeleton.default
+++ b/jflex/src/main/resources/jflex/skeleton.default
@@ -39,7 +39,7 @@
    * This buffer contains the current text to be matched and is the source of the {@link #yytext()}
    * string.
    */
-  private char zzBuffer[] = new char[ZZ_BUFFERSIZE];
+  private char zzBuffer[] = new char[Math.min(ZZ_BUFFERSIZE, zzMaxBufferLen())];
 
   /** Text position at the last accepting state. */
   private int zzMarkedPos;
@@ -95,9 +95,9 @@
     }
 
     /* is the buffer big enough? */
-    if (zzCurrentPos >= zzBuffer.length - zzFinalHighSurrogate) {
+    if (zzCanGrow(zzBuffer.length) && zzCurrentPos >= zzBuffer.length - zzFinalHighSurrogate) {
       /* if not: blow it up */
-      char newBuffer[] = new char[zzBuffer.length * 2];
+      char newBuffer[] = new char[Math.min(zzBuffer.length * 2, zzMaxBufferLen())];
       System.arraycopy(zzBuffer, 0, newBuffer, 0, zzBuffer.length);
       zzBuffer = newBuffer;
       zzEndRead += zzFinalHighSurrogate;
@@ -110,8 +110,13 @@
 
     /* not supposed to occur according to specification of java.io.Reader */
     if (numRead == 0) {
-      throw new java.io.IOException(
-          "Reader returned 0 characters. See JFlex examples/zero-reader for a workaround.");
+      if (requested == 0) {
+        throw new java.io.EOFException("Scan buffer limit reached ["+zzBuffer.length+"]");
+      }
+      else {
+        throw new java.io.IOException(
+            "Reader returned 0 characters. See JFlex examples/zero-reader for a workaround.");
+      }
     }
     if (numRead > 0) {
       zzEndRead += numRead;
@@ -169,8 +174,9 @@
     zzEOFDone = false;
     yyResetPosition();
     zzLexicalState = YYINITIAL;
-    if (zzBuffer.length > ZZ_BUFFERSIZE) {
-      zzBuffer = new char[ZZ_BUFFERSIZE];
+    int initBufferSize = Math.min(ZZ_BUFFERSIZE, zzMaxBufferLen());
+    if (zzBuffer.length > initBufferSize) {
+      zzBuffer = new char[initBufferSize];
     }
   }
 


### PR DESCRIPTION
New directive

    %token_size_limit <limit>

where `<limit>` is a Java number literal or qualified identifier provides an optional hard limit on token length.

The scanner buffer will not be increased beyond this length limit and if a longer token is encountered the scanner with throw an EOFException.

This is for applications that require memory limits when parsing untrusted input.

Implements https://github.com/jflex-de/jflex/issues/197