### PR TITLE
slight performance improvement for buffer limit

### DIFF
--- a/benchmark/src/main/java/jflex/benchmark/JFlexBench.java
+++ b/benchmark/src/main/java/jflex/benchmark/JFlexBench.java
@@ -18,10 +18,10 @@ import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 
-// @BenchmarkMode({Mode.AverageTime, Mode.SampleTime, Mode.SingleShotTime})
-@BenchmarkMode({Mode.AverageTime, Mode.SingleShotTime})
+@BenchmarkMode({Mode.AverageTime, Mode.SampleTime, Mode.SingleShotTime})
+// @BenchmarkMode({Mode.AverageTime, Mode.SingleShotTime})
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
-@Fork(value = 1)
+@Fork(value = 3)
 public class JFlexBench {
 
   @State(Scope.Benchmark)
@@ -30,7 +30,7 @@ public class JFlexBench {
      * Factor by which to scale the input size. We should see a benchmark time roughly linear in the
      * factor, i.e. the first time times 10 and 100.
      */
-    @Param({"100", "1000", "10000"})
+    @Param({"1000", "10000"})
     public int factor;
 
     @Param({"1", "2"})
@@ -110,7 +110,8 @@ public class JFlexBench {
    * The base line: a single continuous pass accessing each character once, through a buffer filled
    * by a reader in one single reader invocation.
    */
-  @Benchmark
+  // uncomment to enable baseline
+  // @Benchmark
   public void baselineReader(LexerState state, Blackhole bh) throws IOException {
     char[] buffer = new char[state.length];
     state.reader.reset();

--- a/jflex/src/main/java/jflex/generator/Emitter.java
+++ b/jflex/src/main/java/jflex/generator/Emitter.java
@@ -1071,17 +1071,12 @@ public final class Emitter {
     }
     println("  }");
     println();
-    println("  /**");
-    println("   * Determine whether the scanner buffer can grow to accommodate a larger token.");
-    println("   *");
-    println("   * @param len the current length of the buffer.");
-    println("   * @return true iff the scanner buffer can grow further.");
-    println("   */");
-    println("  private boolean zzCanGrow(int len) {");
+    println("  /**  Whether the scanner buffer can grow to accommodate a larger token. */");
+    println("  private boolean zzCanGrow() {");
     if (limit == null) {
       println("    return true;");
     } else {
-      println("    return len < zzMaxBufferLen();");
+      println("    return zzBuffer.length < " + limit + ";");
     }
     println("  }");
     println();

--- a/jflex/src/main/jflex/LexScan.flex
+++ b/jflex/src/main/jflex/LexScan.flex
@@ -94,12 +94,12 @@ import jflex.skeleton.Skeleton;
   // Interface for the new skeleton that expects zzCanGrow() and zzMaxBufferLen()
   // These will be inserted by JFlex >= 1.9.0, but we are generating with JFlex 1.8.2
   // TODO(lsf): remove this method when JFlex 1.9.0 is released
-  private boolean zzCanGrow(int len) {
+  private static boolean zzCanGrow() {
     return true;
   }
 
   // TODO(lsf): remove this method when JFlex 1.9.0 is released
-  private int zzMaxBufferLen() {
+  private static int zzMaxBufferLen() {
     return Integer.MAX_VALUE;
   }
 %}

--- a/jflex/src/main/jflex/skeleton.nested
+++ b/jflex/src/main/jflex/skeleton.nested
@@ -136,8 +136,8 @@
     }
 
     /* is the buffer big enough? */
-    if (zzCanGrow(zzBuffer.length) && zzCurrentPos >= zzBuffer.length - zzFinalHighSurrogate) {
-      /* if not: blow it up */
+    if (zzCurrentPos >= zzBuffer.length - zzFinalHighSurrogate && zzCanGrow()) {
+      /* if not, and it can grow: blow it up */
       char newBuffer[] = new char[Math.min(zzBuffer.length * 2, zzMaxBufferLen())];
       System.arraycopy(zzBuffer, 0, newBuffer, 0, zzBuffer.length);
       zzBuffer = newBuffer;

--- a/jflex/src/main/resources/jflex/skeleton.default
+++ b/jflex/src/main/resources/jflex/skeleton.default
@@ -95,8 +95,8 @@
     }
 
     /* is the buffer big enough? */
-    if (zzCanGrow(zzBuffer.length) && zzCurrentPos >= zzBuffer.length - zzFinalHighSurrogate) {
-      /* if not: blow it up */
+    if (zzCurrentPos >= zzBuffer.length - zzFinalHighSurrogate && zzCanGrow()) {
+      /* if not, and it can grow: blow it up */
       char newBuffer[] = new char[Math.min(zzBuffer.length * 2, zzMaxBufferLen())];
       System.arraycopy(zzBuffer, 0, newBuffer, 0, zzBuffer.length);
       zzBuffer = newBuffer;


### PR DESCRIPTION
Benchmark results for MacOS, openjdk11:

```
JFlexBench.noActionLexer                                 10000        1    avgt    15  17.419 ±  0.152  ms/op
JFlexBench.noActionLexer                                 10000        2    avgt    15  17.370 ±  0.046  ms/op
JFlexBench.noActionPreLimit                              10000        1    avgt    15  17.513 ±  0.048  ms/op
JFlexBench.noActionPreLimit                              10000        2    avgt    15  17.531 ±  0.438  ms/op
JFlexBench.noActionLexer                                 10000        1  sample  8626  17.397 ±  0.012  ms/op
JFlexBench.noActionLexer:noActionLexer·p0.00             10000        1  sample        16.941           ms/op
JFlexBench.noActionLexer:noActionLexer·p0.50             10000        1  sample        17.334           ms/op
JFlexBench.noActionLexer:noActionLexer·p0.90             10000        1  sample        17.826           ms/op
JFlexBench.noActionLexer:noActionLexer·p0.95             10000        1  sample        17.957           ms/op
JFlexBench.noActionLexer:noActionLexer·p0.99             10000        1  sample        18.374           ms/op
JFlexBench.noActionLexer:noActionLexer·p0.999            10000        1  sample        19.313           ms/op
JFlexBench.noActionLexer:noActionLexer·p0.9999           10000        1  sample        21.299           ms/op
JFlexBench.noActionLexer:noActionLexer·p1.00             10000        1  sample        21.299           ms/op
JFlexBench.noActionLexer                                 10000        2  sample  8623  17.403 ±  0.019  ms/op
JFlexBench.noActionLexer:noActionLexer·p0.00             10000        2  sample        16.908           ms/op
JFlexBench.noActionLexer:noActionLexer·p0.50             10000        2  sample        17.334           ms/op
JFlexBench.noActionLexer:noActionLexer·p0.90             10000        2  sample        17.760           ms/op
JFlexBench.noActionLexer:noActionLexer·p0.95             10000        2  sample        17.891           ms/op
JFlexBench.noActionLexer:noActionLexer·p0.99             10000        2  sample        18.547           ms/op
JFlexBench.noActionLexer:noActionLexer·p0.999            10000        2  sample        23.704           ms/op
JFlexBench.noActionLexer:noActionLexer·p0.9999           10000        2  sample        28.344           ms/op
JFlexBench.noActionLexer:noActionLexer·p1.00             10000        2  sample        28.344           ms/op
JFlexBench.noActionPreLimit                              10000        1  sample  8566  17.520 ±  0.011  ms/op
JFlexBench.noActionPreLimit:noActionPreLimit·p0.00       10000        1  sample        17.007           ms/op
JFlexBench.noActionPreLimit:noActionPreLimit·p0.50       10000        1  sample        17.465           ms/op
JFlexBench.noActionPreLimit:noActionPreLimit·p0.90       10000        1  sample        17.924           ms/op
JFlexBench.noActionPreLimit:noActionPreLimit·p0.95       10000        1  sample        18.055           ms/op
JFlexBench.noActionPreLimit:noActionPreLimit·p0.99       10000        1  sample        18.383           ms/op
JFlexBench.noActionPreLimit:noActionPreLimit·p0.999      10000        1  sample        19.048           ms/op
JFlexBench.noActionPreLimit:noActionPreLimit·p0.9999     10000        1  sample        25.395           ms/op
JFlexBench.noActionPreLimit:noActionPreLimit·p1.00       10000        1  sample        25.395           ms/op
JFlexBench.noActionPreLimit                              10000        2  sample  8650  17.347 ±  0.015  ms/op
JFlexBench.noActionPreLimit:noActionPreLimit·p0.00       10000        2  sample        16.728           ms/op
JFlexBench.noActionPreLimit:noActionPreLimit·p0.50       10000        2  sample        17.302           ms/op
JFlexBench.noActionPreLimit:noActionPreLimit·p0.90       10000        2  sample        17.727           ms/op
JFlexBench.noActionPreLimit:noActionPreLimit·p0.95       10000        2  sample        17.859           ms/op
JFlexBench.noActionPreLimit:noActionPreLimit·p0.99       10000        2  sample        18.219           ms/op
JFlexBench.noActionPreLimit:noActionPreLimit·p0.999      10000        2  sample        23.331           ms/op
JFlexBench.noActionPreLimit:noActionPreLimit·p0.9999     10000        2  sample        25.231           ms/op
JFlexBench.noActionPreLimit:noActionPreLimit·p1.00       10000        2  sample        25.231           ms/op
JFlexBench.noActionLexer                                 10000        1      ss     3  32.328 ± 40.367  ms/op
JFlexBench.noActionLexer                                 10000        2      ss     3  36.597 ±  7.683  ms/op
JFlexBench.noActionPreLimit                              10000        1      ss     3  31.009 ±  3.442  ms/op
JFlexBench.noActionPreLimit                              10000        2      ss     3  36.552 ±  7.084  ms/op
````

and for Linux, jdk17 (on a faster machine):
```
JFlexBench.baselineReader         100        1  avgt   20   0.013 ±  0.001  ms/op
JFlexBench.baselineReader         100        2  avgt   20   0.014 ±  0.001  ms/op
JFlexBench.baselineReader        1000        1  avgt   20   0.147 ±  0.004  ms/op
JFlexBench.baselineReader        1000        2  avgt   20   0.158 ±  0.003  ms/op
JFlexBench.baselineReader       10000        1  avgt   20   1.873 ±  0.041  ms/op
JFlexBench.baselineReader       10000        2  avgt   20   2.007 ±  0.046  ms/op
JFlexBench.noAction17Lexer        100        1  avgt   20   0.136 ±  0.002  ms/op
JFlexBench.noAction17Lexer        100        2  avgt   20   0.127 ±  0.007  ms/op
JFlexBench.noAction17Lexer       1000        1  avgt   20   1.354 ±  0.030  ms/op
JFlexBench.noAction17Lexer       1000        2  avgt   20   1.364 ±  0.050  ms/op
JFlexBench.noAction17Lexer      10000        1  avgt   20  13.313 ±  0.065  ms/op
JFlexBench.noAction17Lexer      10000        2  avgt   20  12.645 ±  0.027  ms/op
JFlexBench.noAction18Lexer        100        1  avgt   20   0.128 ±  0.001  ms/op
JFlexBench.noAction18Lexer        100        2  avgt   20   0.123 ±  0.002  ms/op
JFlexBench.noAction18Lexer       1000        1  avgt   20   1.306 ±  0.043  ms/op
JFlexBench.noAction18Lexer       1000        2  avgt   20   1.210 ±  0.030  ms/op
JFlexBench.noAction18Lexer      10000        1  avgt   20  13.390 ±  0.503  ms/op
JFlexBench.noAction18Lexer      10000        2  avgt   20  12.159 ±  0.561  ms/op
JFlexBench.noActionLexer          100        1  avgt   20   0.130 ±  0.004  ms/op
JFlexBench.noActionLexer          100        2  avgt   20   0.121 ±  0.001  ms/op
JFlexBench.noActionLexer         1000        1  avgt   20   1.287 ±  0.029  ms/op
JFlexBench.noActionLexer         1000        2  avgt   20   1.207 ±  0.024  ms/op
JFlexBench.noActionLexer        10000        1  avgt   20  12.647 ±  0.138  ms/op
JFlexBench.noActionLexer        10000        2  avgt   20  11.787 ±  0.058  ms/op
JFlexBench.noActionPreLimit       100        1  avgt   20   0.129 ±  0.002  ms/op
JFlexBench.noActionPreLimit       100        2  avgt   20   0.121 ±  0.001  ms/op
JFlexBench.noActionPreLimit      1000        1  avgt   20   1.275 ±  0.022  ms/op
JFlexBench.noActionPreLimit      1000        2  avgt   20   1.195 ±  0.005  ms/op
JFlexBench.noActionPreLimit     10000        1  avgt   20  12.655 ±  0.086  ms/op
JFlexBench.noActionPreLimit     10000        2  avgt   20  12.083 ±  0.237  ms/op
JFlexBench.baselineReader         100        1    ss    4   0.783 ±  0.015  ms/op
JFlexBench.baselineReader         100        2    ss    4   1.349 ±  0.085  ms/op
JFlexBench.baselineReader        1000        1    ss    4   2.861 ±  0.104  ms/op
JFlexBench.baselineReader        1000        2    ss    4   7.888 ±  0.464  ms/op
JFlexBench.baselineReader       10000        1    ss    4   9.048 ±  1.260  ms/op
JFlexBench.baselineReader       10000        2    ss    4  10.414 ±  0.245  ms/op
JFlexBench.noAction17Lexer        100        1    ss    4   5.693 ±  0.112  ms/op
JFlexBench.noAction17Lexer        100        2    ss    4   6.270 ±  0.253  ms/op
JFlexBench.noAction17Lexer       1000        1    ss    4  10.184 ±  0.469  ms/op
JFlexBench.noAction17Lexer       1000        2    ss    4  11.197 ±  0.468  ms/op
JFlexBench.noAction17Lexer      10000        1    ss    4  26.684 ±  8.104  ms/op
JFlexBench.noAction17Lexer      10000        2    ss    4  25.583 ±  1.708  ms/op
JFlexBench.noAction18Lexer        100        1    ss    4   3.302 ±  0.365  ms/op
JFlexBench.noAction18Lexer        100        2    ss    4   3.850 ±  0.110  ms/op
JFlexBench.noAction18Lexer       1000        1    ss    4   8.303 ±  1.133  ms/op
JFlexBench.noAction18Lexer       1000        2    ss    4   9.211 ±  0.683  ms/op
JFlexBench.noAction18Lexer      10000        1    ss    4  22.780 ±  6.612  ms/op
JFlexBench.noAction18Lexer      10000        2    ss    4  22.966 ±  1.541  ms/op
JFlexBench.noActionLexer          100        1    ss    4   3.347 ±  0.463  ms/op
JFlexBench.noActionLexer          100        2    ss    4   3.922 ±  0.151  ms/op
JFlexBench.noActionLexer         1000        1    ss    4   8.175 ±  0.050  ms/op
JFlexBench.noActionLexer         1000        2    ss    4   9.359 ±  1.565  ms/op
JFlexBench.noActionLexer        10000        1    ss    4  22.347 ±  1.914  ms/op
JFlexBench.noActionLexer        10000        2    ss    4  23.109 ±  2.914  ms/op
JFlexBench.noActionPreLimit       100        1    ss    4   3.310 ±  0.262  ms/op
JFlexBench.noActionPreLimit       100        2    ss    4   3.884 ±  0.310  ms/op
JFlexBench.noActionPreLimit      1000        1    ss    4   8.168 ±  0.168  ms/op
JFlexBench.noActionPreLimit      1000        2    ss    4   9.203 ±  0.701  ms/op
JFlexBench.noActionPreLimit     10000        1    ss    4  22.166 ±  1.662  ms/op
JFlexBench.noActionPreLimit     10000        2    ss    4  23.805 ±  9.488  ms/op
```

Difference is in the noise, maybe slightly faster (although there is no reason it should be faster).