### PR TITLE
github: make all plugins available for docs build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,7 +109,7 @@ jobs:
         cache: maven
     - name: '🔨 Build JFlex jar'
       run: |
-        cd jflex; mvn -Pfastbuild install
+        mvn -Pfastbuild install
     - name: '📝 Javadoc'
       run: |
         mvn javadoc:javadoc


### PR DESCRIPTION
The workflow is sometimes failing on jflex-maven-plugin not being available.