### PR TITLE
github: test more java lts versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        java: [ 8, 11, 13 ]
+        java: [ 8, 11, 17 ]
       fail-fast: false
     steps:
     - uses: actions/checkout@v3
@@ -81,7 +81,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        java: [ 8, 13 ]
+        java: [ 8, 11, 17 ]
       fail-fast: false
     steps:
     - uses: actions/checkout@v3
@@ -99,12 +99,16 @@ jobs:
   javadoc:
     name: Javadoc
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: [ 8, 11, 17 ]
+      fail-fast: false
     steps:
     - uses: actions/checkout@v3
     - name: Set up JDK
       uses: actions/setup-java@v3
       with:
-        java-version: 8
+        java-version: ${{ matrix.java }}
         distribution: zulu
         cache: maven
     - name: '🔨 Build JFlex jar'


### PR DESCRIPTION
Test JDKs 8, 11, and 17 by default. JDK 7 is no longer supported by JFlex.