### PR TITLE
docs: support newer pandoc versions that use `--citeproc`

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -4,7 +4,7 @@
 # Makefile for jflex documentation (ps + pdf + html)
 
 VERSION=1.9.0-SNAPSHOT
-RELEASE_DATE=28 February 2020
+RELEASE_DATE=5 February 2023
 UNICODE_VER=12.1
 
 all: pdf html

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -21,7 +21,7 @@ md/manual.md: md/head.md md/toc.md md/intro.md md/installing.md \
 	cat $^ > $@
 
 manual.html: manual.mdx
-	pandoc --standalone --css manual.css --filter pandoc-citeproc -f markdown $< -o $@
+	pandoc --standalone --css manual.css $(shell ./citeproc-arg) -f markdown $< -o $@
 
 #dependency manual.tex would fire manual.md -> .tex conversion
 xmanual.pdf: xmanual.tex intro.tex installing.tex example.tex lex-specs.tex \

--- a/docs/citeproc-arg
+++ b/docs/citeproc-arg
@@ -1,0 +1,24 @@
+#!/bin/bash
+#
+# Copyright 2023, Gerwin Klein
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Pandoc versions >= 2.11 use --citeproc
+# Pandoc versions < 2.11 use --filter pandoc-citeproc
+#
+# This wrapper checks the version of pandoc and returns the appropriate
+# command line argument.
+#
+# Pandoc versions are assumed to be of the form "major.minor". This script will
+# fail with an error if they are not.
+
+VERSION=$(pandoc --version | head -n 1 | cut -d ' ' -f 2)
+
+MAJOR=$(echo $VERSION | cut -d '.' -f 1)
+MINOR=$(echo $VERSION | cut -d '.' -f 2)
+
+if [ $MAJOR -gt 2 ] || [ $MAJOR -eq 2 -a $MINOR -ge 11 ]; then
+    echo "--citeproc"
+else
+    echo "--filter pandoc-citeproc"
+fi


### PR DESCRIPTION
But keep support for older versions, because CI uses pandoc 2.9, which still needs `--filter pandoc-citeproc`.