### PR TITLE
Fix char class normalisation for overlapping class content

### DIFF
--- a/javatests/de/jflex/testcase/ccl_neg/BUILD.bazel
+++ b/javatests/de/jflex/testcase/ccl_neg/BUILD.bazel
@@ -1,0 +1,31 @@
+# Copyright 2023, Gerwin Klein
+# SPDX-License-Identifier: BSD-3-Clause
+
+load("@jflex_rules//jflex:jflex.bzl", "jflex")
+load("//scripts:check_deps.bzl", "check_deps")
+
+check_deps(
+    name = "deps_to_bootstrap_jflex_test",
+    prohibited = "@jflex_rules//jflex:jflex_bin",
+)
+
+jflex(
+    name = "ccl_neg_scanner",
+    srcs = ["neg_overlap.flex"],
+    jflex_bin = "//jflex:jflex_bin",
+    outputs = ["CCLNeg.java"],
+)
+
+java_test(
+    name = "CCLNegTest",
+    size = "small",
+    srcs = [
+        "CCLNegTest.java",
+        ":ccl_neg_scanner",
+    ],
+    deps = [
+        "//java/de/jflex/util/scanner:scanner_factory",
+        "//third_party/com/google/guava",
+        "//third_party/com/google/truth",
+    ],
+)

--- a/javatests/de/jflex/testcase/ccl_neg/CCLNegTest.java
+++ b/javatests/de/jflex/testcase/ccl_neg/CCLNegTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020, Google, LLC.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+package de.jflex.testcase.ccl_neg;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import de.jflex.util.scanner.ScannerFactory;
+import org.junit.Test;
+
+/** Test character class syntax. */
+public class CCLNegTest {
+
+  @Test
+  public void test() throws Exception {
+    ScannerFactory<CCLNeg> scannerFactory = ScannerFactory.of(CCLNeg::new);
+    CCLNeg scanner = scannerFactory.createScannerWithContent("not_space then\n space");
+
+    assertThat(scanner.yylex()).isEqualTo(1); // not space
+    assertThat(scanner.yylex()).isEqualTo(0); // default
+    assertThat(scanner.yylex()).isEqualTo(1); // not space
+    assertThat(scanner.yylex()).isEqualTo(2); // nl
+    assertThat(scanner.yylex()).isEqualTo(0); // default
+    assertThat(scanner.yylex()).isEqualTo(1); // not space
+    assertThat(scanner.yylex()).isEqualTo(-1); // EOF
+  }
+}

--- a/javatests/de/jflex/testcase/ccl_neg/neg_overlap.flex
+++ b/javatests/de/jflex/testcase/ccl_neg/neg_overlap.flex
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2023, Gerwin Klein <lsf@jflex.de>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+package de.jflex.testcase.ccl_neg;
+
+%%
+
+%public
+%class CCLNeg
+%type int
+
+%%
+
+// negated char class with overlapping content
+[^\n\s]+   { return 1; }
+
+// something that intersects with the negated char class
+[\n]+      { return 2; }
+
+// default
+.          { return 0; }
+
+<<EOF>>    { return -1; }

--- a/jflex/src/main/java/jflex/chars/Interval.java
+++ b/jflex/src/main/java/jflex/chars/Interval.java
@@ -28,8 +28,8 @@ public final class Interval implements Iterable<Integer> {
    * @param end last codepoint the interval contains
    */
   public Interval(int start, int end) {
-    this.start = start;
-    this.end = end;
+    this.start = Math.min(start, end);
+    this.end = Math.max(start, end);
     assert invariants();
   }
 

--- a/jflex/src/main/java/jflex/core/RegExp.java
+++ b/jflex/src/main/java/jflex/core/RegExp.java
@@ -388,6 +388,7 @@ public class RegExp {
           return new RegExp1(type, unary.content);
 
         case sym.CCLASS:
+        case sym.CCLASSNOT:
           {
             unary = (RegExp1) this;
             List<RegExp> contents = (List<RegExp>) unary.content;
@@ -396,19 +397,8 @@ public class RegExp {
               RegExp1 n = checkPrimClass(r.normaliseCCLs(f, line));
               set.add((IntCharSet) n.content);
             }
-            return new RegExp1(sym.PRIMCLASS, set);
-          }
-
-        case sym.CCLASSNOT:
-          {
-            unary = (RegExp1) this;
-            List<RegExp> contents = (List<RegExp>) unary.content;
-            IntCharSet set = IntCharSet.allChars();
-            for (RegExp r : contents) {
-              RegExp1 n = checkPrimClass(r.normaliseCCLs(f, line));
-              set.sub((IntCharSet) n.content);
-            }
-            return new RegExp1(sym.PRIMCLASS, set);
+            return new RegExp1(
+                sym.PRIMCLASS, type == sym.CCLASS ? set : IntCharSet.complementOf(set));
           }
 
         case sym.CCLASSOP:

--- a/jflex/src/main/java/jflex/core/unicode/CharClasses.java
+++ b/jflex/src/main/java/jflex/core/unicode/CharClasses.java
@@ -161,7 +161,7 @@ public class CharClasses {
     if (caseless) set = set.getCaseless(unicodeProps);
 
     if (DEBUG) {
-      Out.dump("makeClass(" + set + ")");
+      Out.dump("makeClass(" + set + ", " + caseless + ")");
       dump();
     }
 


### PR DESCRIPTION
In a negated character class that has overlapping content, such as `[^\n\s]`, the normalisation code is violating a precondition of `IntCharSet.sub()` and leaves the class content in an inconsistent state. This either triggers an exception at generation time if another set operation interacts with the inconsistent part, or may lead to matching wrong input at runtime if nothing else interacts with the set.

This PR fixes the problem by first computing the union of the class content `\n\s`, which becomes a single set (joining the overlapping parts) and then computing the complement of that set.

- [x] enforce invariant in `Interval` class
- [x] avoid violating `sub` precondition
- [x] add regression test case for negating overlapping char class content

Fixes #1065 