### PR TITLE
skip deployment of some modules

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -62,6 +62,26 @@ For more information, see [Sonatype repository usage guide][sonatype-repo-usage]
 - make sure `UNICODE_VERSION` in the Makefile is up to date
 - check that all new features are included in the manual
 
+### Check CUP maven plugin
+
+The CUP plugin has its own versioning scheme and if the version has not changed
+the release will fail. If there have not been any changes, the deployment can
+be skipped by adding
+
+```xml
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+    </plugins>
+```
+
+to the [pom.xml](./cup-maven-plugin/pom.xml).
+
 ### Run the `prepare-release.pl` script
 
 ```sh

--- a/benchmark/pom.xml
+++ b/benchmark/pom.xml
@@ -70,6 +70,13 @@
         </executions>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+      <plugin>
         <artifactId>maven-resources-plugin</artifactId>
         <executions>
           <execution>

--- a/cup-maven-plugin/pom.xml
+++ b/cup-maven-plugin/pom.xml
@@ -90,6 +90,16 @@
         <directory>resources</directory>
       </resource>
     </resources>
+    <plugins>
+      <!-- remove this if there have been updates to the cup plugin: -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+    </plugins>
   </build>
 
 </project>


### PR DESCRIPTION
- benchmark module doesn't need to be deployed to Sonatype, it's mostly used when you're building from source anyway
- cup-maven-plugin only should be deployed when something (esp the version number) has changed